### PR TITLE
Flux calibration

### DIFF
--- a/katsdpcal/calprocs.py
+++ b/katsdpcal/calprocs.py
@@ -835,6 +835,7 @@ def F_cal(scaled_solns, unscaled_solns):
             product_F_SNR[targ] = error_SJy
     return product_F, product_F_SNR
 
+
 # --------------------------------------------------------------------------------------------------
 # --- Baseline ordering
 # --------------------------------------------------------------------------------------------------
@@ -1419,4 +1420,3 @@ def snr_antenna(data, weights, bls_lookup, flag_ants=None):
         snr[..., a] = 1. / rms
 
     return snr
-

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1061,7 +1061,8 @@ class Pipeline(Task):
             'KCROSS_DIODE': solutions.CalSolutionStoreLatest('KCROSS_DIODE'),
             'B': solutions.CalSolutionStoreLatest('B'),
             'BCROSS_DIODE': solutions.CalSolutionStoreLatest('BCROSS_DIODE'),
-            'G': solutions.CalSolutionStore('G')
+            'G': solutions.CalSolutionStore('G'),
+            'G_FLUX': solutions.CalSolutionStore('G')
         }
 
     def get_sensors(self):

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -754,7 +754,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
             elif 'gaincal' not in taglist:
                 # If there is no model and the target isn't a gaincal as well
                 # scale the gain and save to G_SCALE
-                scale_solution(solution_stores, g_solns)
+                scale_solution(solution_stores, g_soln)
 
         # GAIN
         if any('gaincal' in k for k in taglist):

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -709,18 +709,19 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
             # interpolated solutions (without NaNs) are stored in the solution store
             # so they can be applied to target/calibrator data without propagating NaNs
             solution_stores['B'].add(b_soln_nonans)
-            # ---------------------------------------
-            # G solution with flux model for BPCals
-            logger.info('Solving for G on bandpass calibrator %s', target_name)
-            # Only K and B for bandpass G
-            solns_to_apply = get_solns_to_apply(s, solution_stores, ['K', 'B'])
-            dumps_per_solint = scan_slice.stop - scan_slice.start
-            g_solint = dumps_per_solint * dump_period
-            g_soln = shared_solve(ts, parameters, None,
-                                  parameters['g_bchan'], parameters['g_echan'],
-                                  s.g_sol, g_solint, g0_h, pre_apply=solns_to_apply)
-            # Save solution to solution store
-            save_solution(None, None, solution_stores['G_FLUX'], g_soln)
+            # --------------------------------------------------------------
+            # G solution with flux model for BPCals only if there is a model
+            if s.model is not None:
+                logger.info('Solving for G on bandpass calibrator %s', target_name)
+                # Only K and B for bandpass G
+                solns_to_apply = get_solns_to_apply(s, solution_stores, ['K', 'B'])
+                dumps_per_solint = scan_slice.stop - scan_slice.start
+                g_solint = dumps_per_solint * dump_period
+                g_soln = shared_solve(ts, parameters, None,
+                                      parameters['g_bchan'], parameters['g_echan'],
+                                      s.g_sol, g_solint, g0_h, pre_apply=solns_to_apply)
+                # Save solution to solution store
+                save_solution(None, None, solution_stores['G_FLUX'], g_soln)
 
         # GAIN
         if any('gaincal' in k for k in taglist):

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -147,7 +147,8 @@ def get_solns_to_apply(s, solution_stores, sol_list, time_range=[], G_target=Non
         if X.startswith('G'):
             # get G values for a two hour range on either side of target scan
             t0, t1 = time_range
-            soln = solution_stores[X].get_range(t0 - 2. * 60. * 60., t1 + 2. * 60. * 60, target=G_target)
+            soln = solution_stores[X].get_range(t0 - 2. * 60. * 60.,
+                                                t1 + 2. * 60. * 60, target=G_target)
         else:
             # get most recent solution value
             soln = solution_stores[X].latest

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -369,7 +369,7 @@ class Scan:
                                 self.cross_ant.bls_lookup, g0,
                                 self.refant, **kwargs)
 
-        cal_soln = CalSolutions('G', g_soln, ave_times)
+        cal_soln = CalSolutions('G', g_soln, ave_times, soltarget=self.target.name)
         if calc_snr:
             ave_vis_t, ave_weights_t = da.compute(ave_vis_t, ave_weights_t)
             # use non channel-averaged data to calculate poor antennas,
@@ -381,7 +381,7 @@ class Scan:
             # use channel averaged data to calculate snr
             resid, weights = self._resid(cal_soln, ave_vis, ave_weights, channel_freqs=g_freqs)
             snr = calprocs.snr_antenna(resid, weights, self.cross_ant.bls_lookup, mask[:, 0:1, ...])
-            cal_soln = CalSolutions('G', g_soln, ave_times, snr)
+            cal_soln = CalSolutions('G', g_soln, ave_times, soltarget=self.target.name, solsnr=snr)
 
         return cal_soln
 
@@ -428,7 +428,7 @@ class Scan:
         # Set soln to NaN for antennas where the noise diode didn't fire
         if nd is not None:
             bcross_soln = np.where(~nd, np.nan, bcross_soln)
-        return CalSolution('BCROSS_DIODE', bcross_soln, np.average(self.timestamps))
+        return CalSolution('BCROSS_DIODE', bcross_soln, np.average(self.timestamps), self.target.name)
 
     @logsolutiontime
     def kcross_sol(self, bchan=1, echan=None, chan_ave=1, pre_apply=[], nd=None, auto_ant=False):
@@ -514,7 +514,7 @@ class Scan:
         # if auto_ant is True set soln to NaN for antennas where the noise diode didn't fire
         if nd is not None and auto_ant:
             kcross_soln = np.where(~nd, np.nan, kcross_soln)
-        return CalSolution(soln_type, kcross_soln, np.average(self.timestamps))
+        return CalSolution(soln_type, kcross_soln, np.average(self.timestamps), self.target.name)
 
     @logsolutiontime
     def k_sol(self, bchan=1, echan=None, chan_sample=1, pre_apply=[], calc_snr=True):
@@ -569,14 +569,14 @@ class Scan:
                                 self.cross_ant.bls_lookup,
                                 k_freqs, self.refant, True, chan_sample)
 
-        cal_soln = CalSolution('K', k_soln, ave_time)
+        cal_soln = CalSolution('K', k_soln, ave_time, self.target.name)
         if calc_snr:
             resid, weights = self._resid(cal_soln, ave_vis, ave_weights, channel_freqs=k_freqs)
             ant_flags = calprocs.poor_antenna_flags(resid, weights, self.cross_ant.bls_lookup, 0.2)
             snr = calprocs.snr_antenna(resid, weights, self.cross_ant.bls_lookup, ant_flags)
             # remove time axis to match solution shape
             snr = snr[0]
-            cal_soln = CalSolution('K', k_soln, ave_time, snr)
+            cal_soln = CalSolution('K', k_soln, ave_time, self.target.name, snr)
 
         return cal_soln
 
@@ -637,7 +637,7 @@ class Scan:
             b_soln = b_soln[0]
 
         b_soln, ave_vis, ave_weights = da.compute(b_soln, ave_vis, ave_weights)
-        cal_soln = CalSolution('B', b_soln, ave_time)
+        cal_soln = CalSolution('B', b_soln, ave_time, self.target.name)
 
         if calc_snr:
             resid, weights = self._resid(cal_soln, ave_vis, ave_weights)
@@ -645,7 +645,7 @@ class Scan:
             snr = calprocs.snr_antenna(resid, weights, self.cross_ant.bls_lookup, ant_flags)
             # remove time axis to match solution shape
             snr = snr[0]
-            cal_soln = CalSolution('B', b_soln, ave_time, snr)
+            cal_soln = CalSolution('B', b_soln, ave_time, self.target.name, snr)
 
         return cal_soln
 

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -314,7 +314,8 @@ class Scan:
     # Calibration solution functions
 
     @logsolutiontime
-    def g_sol(self, input_solint, g0, bchan=1, echan=0, pre_apply=[], calc_snr=True, use_model=True, **kwargs):
+    def g_sol(self, input_solint, g0, bchan=1, echan=0, pre_apply=[],
+              calc_snr=True, use_model=True, **kwargs):
         """
         Solve for gain
 
@@ -434,7 +435,8 @@ class Scan:
         # Set soln to NaN for antennas where the noise diode didn't fire
         if nd is not None:
             bcross_soln = np.where(~nd, np.nan, bcross_soln)
-        return CalSolution('BCROSS_DIODE', bcross_soln, np.average(self.timestamps), self.target.name)
+        return CalSolution('BCROSS_DIODE', bcross_soln,
+                           np.average(self.timestamps), self.target.name)
 
     @logsolutiontime
     def kcross_sol(self, bchan=1, echan=None, chan_ave=1, pre_apply=[], nd=None, auto_ant=False):

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -314,7 +314,7 @@ class Scan:
     # Calibration solution functions
 
     @logsolutiontime
-    def g_sol(self, input_solint, g0, bchan=1, echan=0, pre_apply=[], calc_snr=True, **kwargs):
+    def g_sol(self, input_solint, g0, bchan=1, echan=0, pre_apply=[], calc_snr=True, use_model=True, **kwargs):
         """
         Solve for gain
 
@@ -332,6 +332,8 @@ class Scan:
             calibration solutions to apply
         calc_snr : bool, optional
             if True calculate SNR for G solution
+        use_model : bool, optional
+            if True correct visibilities by available model
 
         Returns
         -------
@@ -351,9 +353,13 @@ class Scan:
         chan_slice = np.s_[:, bchan:echan, :, :]
 
         g_freqs = self.channel_freqs[bchan:echan]
-        # initialise and apply model, for if this scan target has an associated model
-        self._init_model()
-        fitvis = self._get_solver_model(modvis, chan_select=chan_slice)
+
+        if use_model:
+            # initialise and apply model, if this scan target has an associated model
+            self._init_model()
+            fitvis = self._get_solver_model(modvis, chan_select=chan_slice)
+        else:
+            fitvis = modvis[chan_slice]
 
         # first averge in time over solution interval, for specified channel
         # range (no averaging over channel)

--- a/katsdpcal/solutions.py
+++ b/katsdpcal/solutions.py
@@ -71,31 +71,21 @@ class CalSolutionStore:
         else:
             return None
 
-    def get_range(self, start_time, end_time):
+    def get_range(self, start_time, end_time, target=None):
         """Get the solutions in the interval [start_time, end_time].
+        Optionally only return solutions for a given target.
 
         The returned values are combined into a :class:`CalSolutions`.
         """
         parts = list(self._values.irange_key(start_time, end_time))
+        if target is not None:
+            parts = [part for part in parts if part.target == target]
         if len(parts) > 0:
             values = np.stack([part.values for part in parts])
         else:
             values = np.array([])
         times = np.array([part.time for part in parts])
-        return CalSolutions(self.soltype, values, times)
-
-    def get_target(self, target_name):
-        """Get all solutions with a given target_name.
-
-        Return them in a :class:`CalSolutions`.
-        """
-        parts = [part for part in self._values if part.target == target_name]
-        if len(parts) > 0:
-            values = np.stack([part.values for part in parts])
-        else:
-            values = np.array([])
-        times = np.array([part.time for part in parts])
-        return CalSolutions(self.soltype, values, times, soltarget=target_name)
+        return CalSolutions(self.soltype, values, times, soltarget=target)
 
     def has_target(self, target_name):
         """Return True if solutions with target_name are

--- a/katsdpcal/solutions.py
+++ b/katsdpcal/solutions.py
@@ -51,7 +51,7 @@ class CalSolutionStore:
 
     This stores multiple solutions (in time), but unlike
     :class:`CalSolutions`, each solution is stored separately, and one can query
-    all solutions from a time range.
+    all solutions from a time range or all solutions by target.
     """
     def __init__(self, soltype):
         self.soltype = soltype
@@ -97,6 +97,13 @@ class CalSolutionStore:
             values = np.array([])
         times = np.array([part.time for part in parts])
         return CalSolutions(self.soltype, values, times, soltarget=target_name)
+
+    def has_target(self, target_name):
+        """Return True if solutions with target_name are
+        in the store.
+        """
+        targets = set([value.target for value in self._values])
+        return target_name in targets
 
 
 class CalSolutionStoreLatest:

--- a/katsdpcal/solutions.py
+++ b/katsdpcal/solutions.py
@@ -7,19 +7,21 @@ import numpy as np
 class CalSolution:
     """Calibration solution.
 
-    This represents a solution for a single point in time.
+    This represents a solution for a target for a single point in time.
     """
-    def __init__(self, soltype, solvalues, soltime, solsnr=None):
+    def __init__(self, soltype, solvalues, soltime, soltarget, solsnr=None):
         self.soltype = soltype
         self.values = solvalues
         self.time = soltime
+        self.target = soltarget
         self.snr = solsnr
+
 
     def __str__(self):
         """String representation of calibration solution to help identify it."""
         # Obtain human-friendly timestamp representing the centre of solutions
         timestamp = time.strftime("%H:%M:%S", time.gmtime(self.time))
-        return "{} {} {}".format(self.soltype, self.values.shape, timestamp)
+        return "{} {} {} {}".format(self.soltype, self.target, self.values.shape, timestamp)
 
 
 class CalSolutions:
@@ -27,17 +29,21 @@ class CalSolutions:
 
     This stores multiple solutions (in time) in a single array.
     """
-    def __init__(self, soltype, solvalues, soltimes, solsnr=None):
+    def __init__(self, soltype, solvalues, soltimes, soltarget=None, solsnr=None):
         self.soltype = soltype
         self.values = solvalues
         self.times = soltimes
+        self.target = soltarget
         self.snr = solsnr
 
     def __str__(self):
         """String representation of calibration solution to help identify it."""
         # Obtain human-friendly timestamp representing the centre of solutions
         timestamp = time.strftime("%H:%M:%S", time.gmtime(np.mean(self.times)))
-        return "{} {} {}".format(self.soltype, self.values.shape, timestamp)
+        if self.target:
+            return "{} {} {} {}".format(self.soltype, self.target, self.values.shape, timestamp)
+        else:
+            return "{} {} {}".format(self.soltype, self.values.shape, timestamp)
 
 
 class CalSolutionStore:
@@ -78,6 +84,19 @@ class CalSolutionStore:
             values = np.array([])
         times = np.array([part.time for part in parts])
         return CalSolutions(self.soltype, values, times)
+
+    def get_target(self, target_name):
+        """Get all solutions with a given target_name.
+
+        Return them in a :class:`CalSolutions`.
+        """
+        parts = [part for part in self._values if part.target == target_name]
+        if len(parts) > 0:
+            values = np.stack([part.values for part in parts])
+        else:
+            values = np.array([])
+        times = np.array([part.time for part in parts])
+        return CalSolutions(self.soltype, values, times, soltarget=target_name)
 
 
 class CalSolutionStoreLatest:

--- a/katsdpcal/solutions.py
+++ b/katsdpcal/solutions.py
@@ -16,7 +16,6 @@ class CalSolution:
         self.target = soltarget
         self.snr = solsnr
 
-
     def __str__(self):
         """String representation of calibration solution to help identify it."""
         # Obtain human-friendly timestamp representing the centre of solutions

--- a/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/test/test_calprocs.py
@@ -444,6 +444,45 @@ class TestKAnt(unittest.TestCase):
 
 class TestF_cal(unittest.TestCase):
     """Tests for :func:`katsdpcal.calprocs.F_cal'"""
+    def setUp(self):
+        ntimes = 4
+        self.gains1 = np.ones((ntimes, 5), dtype=np.complex64)
+        self.times1 = np.linspace(0.2, 0.3, ntimes)
+        self.targ1 = ['targ1'] * ntimes
+
+        self.gains2 = np.ones((ntimes, 5), dtype=np.float32) * 10. + \
+            1j * np.ones((ntimes, 5), dtype=np.float32) * 10.
+        self.times2 = np.linspace(0.3, 0.4, ntimes)
+        self.targ2 = ['targ2'] * ntimes
+
+        # All gains NaN
+        self.gains3 = np.full((1, 5), np.nan, dtype=np.complex64)
+        self.times3 = [0.5]
+        self.targ3 = ['targ3']
+
+        # Gains with mismatched shape
+        self.gains4 = np.ones((2, 6), dtype=np.complex64)
+        self.times4 = 0.6
+        self.targ4 = 'targ4'
+
+        self.gains1[0, :] = np.nan
+        self.gains1[:, 2] = np.nan
+        self.gains1[2, 3] = np.nan
+        self.gains1[3, 2] = 10.0
+
+        flux = np.ones((ntimes, 5), dtype=np.float32) * 1. / np.sqrt(2) + \
+            1. / np.sqrt(2) * 1j * np.ones((ntimes, 5), dtype=np.float32)
+        timesflux = np.linspace(0.1, 0.2, ntimes)
+        targflux = ['flux'] * ntimes
+        flux[0, 2] = np.nan + 1j*np.nan
+        flux[1, :] = np.nan + 1j*np.nan
+        self.f_store = self.Gsolution_store(targflux, timesflux, flux)
+
+        self.expect_f1 = 1.0
+        expect_ratio1 = [1., 1., 10., 1., 1.]
+        self.expect_std1 = 2. * 1.253 * np.std(expect_ratio1) / np.sqrt(5)
+        self.expect_f2 = (np.abs(10 + 10j) / 1.) ** 2.
+
     def Gsolution_store(self, targs, times, gains):
         store = CalSolutionStore('G')
         for targ, tm, gain in zip(targs, times, gains):
@@ -451,45 +490,40 @@ class TestF_cal(unittest.TestCase):
             store.add(soln)
         return store
 
-    def test(self):
-        f_gains = np.random.normal(10.0, 0.001, (4, 2, 1000)) + 0j
-        g_gains = np.random.normal(10.0, 1.0, (8, 2, 1000)) + 0j
-        expect_f = 1.0
-        # 0.0410 is empirical
-        expect_f_std = 0.04101 * 2 * 1.253 / np.sqrt((2 * 1000))
-        times = np.linspace(0.1, 0.2, 4)
-        f_store = self.Gsolution_store(['flux'] * 4, times, f_gains)
-        times = np.linspace(0.3, 0.8, 8)
-        g_store = self.Gsolution_store(['gains'] * 8, times, g_gains)
-        prod_f, prod_f_std = calprocs.F_cal(f_store, g_store)
-        self.assertTrue('gains' in prod_f)
-        self.assertTrue('gains' in prod_f_std)
-        np.testing.assert_almost_equal(prod_f['gains'], expect_f, decimal=2)
-        np.testing.assert_almost_equal(prod_f_std['gains'], expect_f_std, decimal=2)
+    def test_basic(self):
+        # Check that F_cal function produces expected result
+        g_store = self.Gsolution_store(self.targ1, self.times1, self.gains1)
+        prod_f, prod_f_std = calprocs.F_cal(self.f_store, g_store, 0., 1.)
+        self.assertTrue('targ1' in prod_f)
+        self.assertTrue('targ1' in prod_f_std)
+        np.testing.assert_almost_equal(prod_f['targ1'], self.expect_f1)
+        np.testing.assert_almost_equal(prod_f_std['targ1'], self.expect_std1)
 
-        # Multiple targets
-        g_gains2 = np.random.normal(8.0, 0.001, (4, 2, 1000)) + \
-            1j * np.random.normal(0.01, 0.001, (4, 2, 1000))
-        expect_f2 = (8.0**2 + 0.1**2) / (10.**2)
-        times = np.linspace(0.3, 0.8, 12)
-        g_store = self.Gsolution_store(['gains'] * 8 + ['gains2'] * 4, times,
-                                       np.vstack([g_gains, g_gains2]))
-        prod_f, _ = calprocs.F_cal(f_store, g_store)
-        self.assertTrue('gains' in prod_f)
-        self.assertTrue('gains2' in prod_f)
-        np.testing.assert_almost_equal(prod_f['gains'], expect_f, decimal=2)
-        np.testing.assert_almost_equal(prod_f['gains2'], expect_f2, decimal=2)
+    def test_multiple_targets(self):
+        # Test the F_cal function with gains produced from multiple targets
+        g_store = self.Gsolution_store(self.targ1 + self.targ2 + self.targ3,
+                                       np.hstack([self.times1, self.times2, self.times3]),
+                                       np.vstack([self.gains1, self.gains2, self.gains3]))
+        prod_f, _ = calprocs.F_cal(self.f_store, g_store, 0., 1.)
+        self.assertTrue('targ1' in prod_f)
+        self.assertTrue('targ2' in prod_f)
+        self.assertTrue('targ3' in prod_f)
+        np.testing.assert_almost_equal(prod_f['targ1'], self.expect_f1)
+        np.testing.assert_almost_equal(prod_f['targ2'], self.expect_f2)
+        np.testing.assert_equal(prod_f['targ3'], np.nan)
 
-        # Mismatched shapes
-        single_g = np.ones((2, 10)) + 1j * np.ones((2, 10))
-        g_store.add(CalSolution('G', single_g, 1.0, 'single_g'))
-        self.assertTrue('gains' in prod_f)
-        self.assertTrue('gains2' in prod_f)
-        self.assertFalse('single_g' in prod_f)
+    def test_mismatched_shapes(self):
+        # Test a set of gains with mismatched shapes don't produce an F product
+        g_store = self.Gsolution_store(self.targ1, self.times1, self.gains1)
+        g_store.add(CalSolution('G', self.gains4, self.times4, self.targ4))
+        prod_f, _ = calprocs.F_cal(self.f_store, g_store, 0., 1.)
+        self.assertTrue('targ1' in prod_f)
+        self.assertFalse('targ4' in prod_f)
 
-        # No F Gains means no solutions
-        f_store = self.Gsolution_store('flux', [], [])
-        prod_f, _ = calprocs.F_cal(f_store, g_store)
+    def test_no_scaled_gains(self):
+        # Test that without scaled gains there is no F product.
+        g_store = self.Gsolution_store(self.targ2, self.times2, self.gains2)
+        prod_f, _ = calprocs.F_cal(self.f_store, g_store, 0.3, 1.)
         self.assertFalse(prod_f)
 
 

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -715,7 +715,10 @@ class TestCalDeviceServer(asynctest.TestCase):
         ret_G, ret_G_ts = cal_product_G[0]
         assert_equal(np.complex64, ret_G.dtype)
         assert_equal(0, np.count_nonzero(np.isnan(ret_G)))
-        ret_BG = ret_B * ret_G[np.newaxis, :, :]
+        # Scale the returned G by the sqrt of the measured flux density of the model
+        ret_F = telstate_cb_cal['measured_flux']
+        ret_F_scale = np.sqrt(ret_F.get(target.name, 1.0))
+        ret_BG = ret_B * ret_G[np.newaxis, :, :] / ret_F_scale
         BG = np.broadcast_to(G[np.newaxis, :, :], ret_BG.shape)
         # cal puts NaNs in B in the channels for which it applies the static
         # RFI mask, interpolate across these

--- a/katsdpcal/test/test_reduction.py
+++ b/katsdpcal/test/test_reduction.py
@@ -74,6 +74,7 @@ class TestSharedSolve(unittest.TestCase):
             self.assertEqual(results[i].soltype, 'K')
             np.testing.assert_array_equal(results[i].values, expected)
             self.assertEqual(results[i].time, 12345.5)
+            self.assertEqual(results[i].target, 'Test')
 
     def test_cal_solution_named(self):
         self._test_cal_solution('K')

--- a/katsdpcal/test/test_reduction.py
+++ b/katsdpcal/test/test_reduction.py
@@ -63,7 +63,7 @@ class TestSharedSolve(unittest.TestCase):
             values = np.arange(123)
             values[0] = bchan
             values[1] = echan
-            return CalSolution(name or 'K', values, 12345.5)
+            return CalSolution(name or 'K', values, 12345.5, 'Test')
 
         results = self.call(name, self.bchan, self.echan, solver)
         expected = np.arange(123)

--- a/katsdpcal/test/test_solutions.py
+++ b/katsdpcal/test/test_solutions.py
@@ -51,17 +51,18 @@ class TestCalSolutionStore(TestCalSolutionStoreLatest):
         np.testing.assert_array_equal(soln.times, [1234.0, 2345.0])
         self.assertIsNone(soln.target)
 
-    def test_get_target(self):
+    def test_get_range_with_target(self):
         self.store.add(self.sol1)
+        self.store.add(self.sol3)
         self.store.add(self.sol4)
-        solns = self.store.get_target(self.sol1.target)
+        solns = self.store.get_range(1234.0, 4567.0, target=self.sol1.target)
         self.assertEqual(solns.soltype, 'G')
         expect_sol1 = np.repeat(np.arange(10)[np.newaxis], 2, axis=0)
         np.testing.assert_array_equal(solns.values, expect_sol1)
         np.testing.assert_array_equal(solns.times, [1234.0, 4567.0])
         self.assertEqual(solns.target, self.sol1.target)
         # Get a nonexistent target
-        solns = self.store.get_target(self.sol2.target)
+        solns = self.store.get_range(1234.0, 2345.0, target=self.sol2.target)
         self.assertEqual(solns.soltype, 'G')
         self.assertEqual(len(solns.values), 0)
         self.assertEqual(len(solns.times), 0)

--- a/katsdpcal/test/test_solutions.py
+++ b/katsdpcal/test/test_solutions.py
@@ -11,10 +11,11 @@ class TestCalSolutionStoreLatest(unittest.TestCase):
     test_cls = CalSolutionStoreLatest
 
     def setUp(self):
-        self.sol1 = CalSolution('G', np.arange(10), 1234.0)
-        self.sol2 = CalSolution('G', np.arange(10, 20), 2345.0)
-        self.sol3 = CalSolution('G', np.arange(30, 40), 3456.0)
-        self.solK = CalSolution('K', np.arange(30, 40), 3456.0)
+        self.sol1 = CalSolution('G', np.arange(10), 1234.0, 'sol1')
+        self.sol2 = CalSolution('G', np.arange(10, 20), 2345.0, 'sol2')
+        self.sol3 = CalSolution('G', np.arange(30, 40), 3456.0, 'sol3')
+        self.solK = CalSolution('K', np.arange(30, 40), 3456.0, 'solK')
+        self.sol4 = CalSolution('G', np.arange(10), 4567.0, 'sol1')
         self.store = self.test_cls('G')
 
     def test_latest_empty(self):
@@ -48,3 +49,22 @@ class TestCalSolutionStore(TestCalSolutionStoreLatest):
         self.assertEqual(soln.soltype, 'G')
         np.testing.assert_array_equal(soln.values, np.arange(20).reshape(2, 10))
         np.testing.assert_array_equal(soln.times, [1234.0, 2345.0])
+        self.assertIsNone(soln.target)
+
+    def test_get_target(self):
+        self.store.add(self.sol1)
+        self.store.add(self.sol4)
+        solns = self.store.get_target(self.sol1.target)
+        self.assertEqual(solns.soltype, 'G')
+        expect_sol1 = np.repeat(np.arange(10)[np.newaxis], 2, axis=0)
+        np.testing.assert_array_equal(solns.values, expect_sol1)
+        np.testing.assert_array_equal(solns.times, [1234.0, 4567.0])
+        self.assertEqual(solns.target, self.sol1.target)
+        # Get a nonexistent target
+        solns = self.store.get_target(self.sol2.target)
+        self.assertEqual(solns.soltype, 'G')
+        self.assertEqual(len(solns.values), 0)
+        self.assertEqual(len(solns.times), 0)
+        self.assertEqual(solns.target, self.sol2.target)
+
+        

--- a/katsdpcal/test/test_solutions.py
+++ b/katsdpcal/test/test_solutions.py
@@ -66,5 +66,3 @@ class TestCalSolutionStore(TestCalSolutionStoreLatest):
         self.assertEqual(len(solns.values), 0)
         self.assertEqual(len(solns.times), 0)
         self.assertEqual(solns.target, self.sol2.target)
-
-        


### PR DESCRIPTION
The basic scheme is to get gains using a flux model for any target tagged `bpcal` which has an associated model (either fancy or just a katpoint target flux model) and store these in a `G_FLUX` solution store. Then bootstrap these scaled gains to anything else labelled `bpcal` (without a model) or `gaincal` which has a `G` solution and store these in a `G_SCALE` solution store.

The square of the scale factor for the un-scaled gains is the derived flux density of the associated target and this is saved to telstate in key `measured_flux` in the cbid_cal namespace, the standard error of the scale factor is stored in the `measured_flux_STD`. The square root of `measured_flux` can be later used to flux calibrate the un-scaled `G` solutions that are stored in telstate. The `G_SCALE` solutions in the store are applied to targets before calibrating the visibilities to produce flux calibrated cal reports.

Because each calibrator will have a different scale factor for `G`, the solution stores have been made target aware. There are some convenience methods to get only solutions for a specific target from a solution store and also to check if a given target is contained within one.

The `measured_flux` is derived and stored before the cal report starts being generated, right after an `ObervationEndEvent`.

Further details are in the individual commit messages.