### PR TITLE
Fix median bug

### DIFF
--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -10,6 +10,7 @@ from . import lsm_dir
 from . import pipelineprocs as pp
 
 import numpy as np
+import dask.array as da
 
 from docutils.core import publish_file
 
@@ -615,7 +616,7 @@ def write_g_freq(report, report_path, targets, av_corr, antenna_names,
         tags = [t for t in kat_target.tags if t in TAG_WHITELIST]
 
         # Get averaged spectrum for gain calibrated targets
-        av_data, av_flags, av_weights = av_corr['{0}_g_spec'.format(target_name)][0]
+        av_data, av_flags, av_weights = da.compute(*av_corr['{0}_g_spec'.format(target_name)][0])
         av_data[av_flags] = np.nan
         logger.info(' Corrected data for {0} shape: {1}'.format(target_name, av_data.shape))
 

--- a/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/test/test_calprocs.py
@@ -415,9 +415,9 @@ class TestNormaliseComplex(unittest.TestCase):
         # Data with NaN weights should be ignored in normalisation factor calculation
         weights[:, 0, 0] = [1, 0, 2, np.nan, 1, 5]
         expected = self.expected
-        expected_angle = -1j * np.pi / 4 * (2 / 5)
+        expected_angle = -1j * np.pi / 8
         expected_amp = 4 / (5 * np.sqrt(2))
-        weights[:, 0, 0] = expected_amp * np.exp(expected_angle)
+        expected[:, 0, 0] = expected_amp * np.exp(expected_angle)
 
         # check for all axes
         for i in [0, 1, 2, -1, -2, -3]:


### PR DESCRIPTION
Fix two bugs I spotted in cal.
 The first is that the report writer was finding a `np.median` on one of the corrected data arrays, but this array was actually a dask array and `np.median` is not supported on dask arrays. 
The second was an error in the tests for the `normalise_complex` function which calculates the complex normalisation factor for a  weighted normalisation. This test was accidentally setting all the weights along the normalisation axis to the same value and therefore just re-running the unweighted normalisation test case.  