### PR TITLE
Add a reference antenna sensor in cal pipeline

### DIFF
--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1082,6 +1082,9 @@ class Pipeline(Task):
                 'number of times the pipeline threw an exception (prometheus: counter)',
                 default=0, initial_status=aiokatcp.Sensor.Status.NOMINAL),
             aiokatcp.Sensor(
+                str, 'pipeline-reference-antenna',
+                'Reference antenna selected by the pipeline'),
+            aiokatcp.Sensor(
                 float, 'pipeline-start-flag-fraction-auto-pol',
                 'Starting flag fraction prior to RFI detection: auto-pol (prometheus: Gauge)'),
             aiokatcp.Sensor(

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -526,6 +526,8 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 parameters['refant_index'] = best_refant_index
                 parameters['refant'] = parameters['antenna_names'][best_refant_index]
                 logger.info('Reference antenna set to %s', parameters['refant'])
+                sensors['pipeline-reference-antenna'].set_value(
+                    parameters['refant'], timestamp=s.timestamps[0])
                 s.refant = best_refant_index
 
             # Add the reference antenna to telstate for each new cbid

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -881,6 +881,7 @@ class TestCalDeviceServer(asynctest.TestCase):
         telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
         refant_name = telstate_cb_cal['refant']
         assert_not_equal(self.antennas[worst_index], refant_name)
+        await self.assert_sensor_value('pipeline-reference-antenna', refant_name.encode())
 
     def prepare_heaps(self, rs, n_times,
                       vis=None, weights=None, weights_channel=None, flags=None):


### PR DESCRIPTION
This is to address jira ticket https://skaafrica.atlassian.net/browse/SPR1-336.
The goal is to ultimately display the reference antenna on the Grafana dashboad. Increasing the
visibility of the selected reference antenna will help the operators debug problems during observations
related to a faulty or flagged reference antenna.