### PR TITLE
Plot targets with `polcal` tag in report

### DIFF
--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -612,7 +612,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                         vis = s.apply(soln, vis, cross_pol=True)
                     logger.info('Averaging corrected auto-corr data for %s:', target_name)
                     data = (vis, s.auto_ant.tf.cross_pol.flags, s.auto_ant.tf.cross_pol.weights)
-                    s.summarize(av_corr, 'auto_cross', data, nchans=1024)
+                    s.summarize(av_corr, target_name + '_auto_cross', data, nchans=1024)
             else:
                 logger.info("Noise diode wasn't fired, no KCROSS_DIODE solution")
 
@@ -661,10 +661,17 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 # ---------------------------------------
                 # KCROSS solution
                 logger.info('Solving for KCROSS on cross-hand delay calibrator %s', target_name)
-                shared_solve(ts, parameters, solution_stores['KCROSS'],
-                             parameters['k_bchan'], parameters['k_echan'],
-                             s.kcross_sol, chan_ave=parameters['kcross_chanave'],
-                             pre_apply=solns_to_apply)
+                kcross_soln = shared_solve(ts, parameters, solution_stores['KCROSS'],
+                                           parameters['k_bchan'], parameters['k_echan'],
+                                           s.kcross_sol, chan_ave=parameters['kcross_chanave'],
+                                           pre_apply=solns_to_apply)
+                solns_to_apply.append(s.interpolate(kcross_soln))
+                vis = s.cross_ant.tf.cross_pol.vis
+                for soln in solns_to_apply:
+                    vis = s.apply(soln, vis, cross_pol=True)
+                logger.info('Averaging corrected cross-pol data for %s:', target_name)
+                data = (vis, s.cross_ant.tf.cross_pol.flags, s.cross_ant.tf.cross_pol.weights)
+                s.summarize(av_corr, target_name + '_cross', data, nchans=1024, refant_only=True)
 
         # BANDPASS
         if any('bpcal' in k for k in taglist):

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -808,8 +808,11 @@ class Scan:
                               * channel_freqs[np.newaxis, :, np.newaxis, np.newaxis])
             return self._apply(g_from_k, vis, cross_pol)
         elif soln.soltype in ['KCROSS_DIODE', 'KCROSS']:
-            # select HV delay at refant
-            soln = soln.values[..., self.refant][..., np.newaxis]
+            if soln.soltype == 'KCROSS_DIODE':
+                # select HV delay at refant
+                soln = soln.values[..., self.refant][..., np.newaxis]
+            else:
+                soln = soln.values
             soln = np.repeat(soln, self.nant, axis=-1)
 
             g_from_k = da.exp(2j * np.pi * soln[:, np.newaxis, :, :]


### PR DESCRIPTION
This addresses jira https://skaafrica.atlassian.net/browse/SR-2014.
The report now includes a plot of the corrected cross-pol phases of all targets tagged with a
`polcal` tag. This produces one plot per scan of a `polcal` calibrator, hopefully this won't be too
onerous as typically there are only a few scans per observation with a `polcal` tagged target.

These plots won't be very useful in the case where the `polcal` target is at a parallactic angle which
degrades the cross-hand signal, in the future it might be useful to include information about the
status of this parallactic angle in the report.