### PR TITLE
Reset the solution stores at capture_init.

### DIFF
--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -726,7 +726,10 @@ class Accumulator:
                 if self._previous is not None:
                     self._logger.info('waiting for %s to finish', self._previous.capture_block_id)
                     await self._previous.done_event.wait()
-
+                # Tell pipeline that a new observation has begun
+                # Only pipeline uses the ObservationStartEvent so there is
+                # no need to send it to any other queue.
+                self.owner.accum_pipeline_queue.put(ObservationStartEvent())
                 await self._accumulate()
                 # Tell the pipeline that the observation ended, but only if there
                 # was something to work on.
@@ -981,8 +984,6 @@ class Accumulator:
         assert not self.capturing, "observation already running"
         logger.info('===========================')
         logger.info('   Starting new observation')
-        # Tell pipeline that a new observation has begun
-        self.accum_pipeline_queue.put(ObservationStartEvent())
         rx = self._make_rx()
         cb = Accumulator._CaptureBlock(self, capture_block_id, rx, self._last_capture_block)
         self._last_capture_block = cb

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -57,6 +57,10 @@ class EnumEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
+class ObservationStartEvent:
+    """capture_init has been requested"""
+
+
 class ObservationEndEvent:
     """An observation has finished upstream"""
     def __init__(self, capture_block_id, start_time, end_time):
@@ -977,6 +981,8 @@ class Accumulator:
         assert not self.capturing, "observation already running"
         logger.info('===========================')
         logger.info('   Starting new observation')
+        # Tell pipeline that a new observation has begun
+        self.accum_pipeline_queue.put(ObservationStartEvent())
         rx = self._make_rx()
         cb = Accumulator._CaptureBlock(self, capture_block_id, rx, self._last_capture_block)
         self._last_capture_block = cb
@@ -1128,7 +1134,10 @@ class Pipeline(Task):
             while True:
                 logger.info('waiting for next event (%s)', self.name)
                 event = self.accum_pipeline_queue.get()
-                if isinstance(event, BufferReadyEvent):
+                if isinstance(event, ObservationStartEvent):
+                    logger.info('Resetting solution stores')
+                    self._reset_solution_stores()
+                elif isinstance(event, BufferReadyEvent):
                     logger.info('buffer with %d slots acquired by %s',
                                 len(event.slots), self.name)
                     start_time = time.time()

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -302,7 +302,7 @@ class TestCalDeviceServer(asynctest.TestCase):
         self.output_streams[key] = stream
         return stream
 
-    def init_itemgroup(self):
+    def init_item_group(self):
         """Initalise a :class:`spead2.send.ItemGroup` and send it to servers."""
         self.ig = spead2.send.ItemGroup()
         self.add_items(self.ig)
@@ -352,7 +352,7 @@ class TestCalDeviceServer(asynctest.TestCase):
             stream = spead2.send.InprocStream(sender_thread_pool, queue)
             stream.set_cnt_sequence(i, self.n_endpoints)
             self.l0_streams[endpoint] = stream
-        self.init_itemgroup()
+        self.init_item_group()
 
         # Need a real function to use in the mock, otherwise it doesn't become
         # a bound method.
@@ -1092,7 +1092,7 @@ class TestCalDeviceServer(asynctest.TestCase):
         np.testing.assert_allclose(expected, actual, rtol=1e-4)
 
     async def wait_for_sensor(self, sensor, value, timeout):
-        """Wait `timeout` seconds for for `sensor` to have `value`."""
+        """Wait `timeout` seconds for `sensor` to have `value`."""
         for i in range(timeout):
             await asyncio.sleep(1)
             rw = await self.get_sensor(sensor)
@@ -1129,7 +1129,7 @@ class TestCalDeviceServer(asynctest.TestCase):
             assert_true(serv_store['G_FLUX'].has_target('J1331+3030'))
 
         # Refresh ItemGroup and send it to servers.
-        self.init_itemgroup()
+        self.init_item_group()
 
         # Set up a new capture block in telstate
         self.populate_telstate_cb(self.telstate, 'cb2')

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -16,7 +16,7 @@ import numba
 import numpy as np
 from nose.tools import (
     assert_equal, assert_is_instance, assert_in, assert_not_in, assert_false, assert_true,
-    assert_almost_equal, assert_not_equal, assert_raises_regex)
+    assert_almost_equal, assert_not_equal, assert_raises_regex, assert_is)
 import asynctest
 
 import spead2
@@ -216,6 +216,17 @@ class TestCalDeviceServer(asynctest.TestCase):
         self.addCleanup(patcher.stop)
         return mock_obj
 
+    def populate_telstate_cb(self, telstate, cb='cb'):
+        telstate_cb_l0 = telstate.view(telstate.join(cb, 'sdp_l0test'))
+        telstate_cb_l0['first_timestamp'] = 100.0
+        telstate_cb = telstate.view(cb)
+        telstate_cb.add('obs_activity', 'track', ts=0)
+        obs_params = {'description' : 'test observation',
+                      'proposal_id' : '123_03',
+                      'sb_id_code' : '123_0005',
+                      'observer' : 'Kim'}
+        telstate_cb['obs_params'] = obs_params
+
     def populate_telstate(self, telstate_l0):
         telstate = telstate_l0.root()
         bls_ordering = []
@@ -249,15 +260,7 @@ class TestCalDeviceServer(asynctest.TestCase):
         telstate_l0['sync_time'] = 1400000000.0
         telstate_l0['excise'] = True
         telstate_l0['need_weights_power_scale'] = True
-        telstate_cb_l0 = telstate.view(telstate.join('cb', 'sdp_l0test'))
-        telstate_cb_l0['first_timestamp'] = 100.0
-        telstate_cb = telstate.view('cb')
-        telstate_cb.add('obs_activity', 'track', ts=0)
-        obs_params = {'description' : 'test observation',
-                      'proposal_id' : '123_03',
-                      'sb_id_code' : '123_0005',
-                      'observer' : 'Kim'}
-        telstate_cb['obs_params'] = obs_params
+        self.populate_telstate_cb(telstate)
         for antenna in self.antennas:
             # The position is irrelevant for now, so just give all the
             # antennas the same position.
@@ -937,6 +940,19 @@ class TestCalDeviceServer(asynctest.TestCase):
             ts += self.telstate.sdp_l0test_int_time
         return heaps
 
+    async def wait_for_heaps(self, num_heaps, timeout):
+        # Wait until num_heaps have been delivered to the accumulator or timeout in secs.
+        for i in range(timeout):
+            await asyncio.sleep(1)
+            heaps = await self.get_sensor('input-heaps-total')
+            total_heaps = sum(int(x) for x in heaps)
+            if total_heaps == num_heaps:
+                print('all heaps received')
+                break
+            print('waiting {} ({}/{} received)'.format(i, total_heaps, num_heaps))
+        else:
+            raise RuntimeError('Timed out waiting for the heaps to be received')
+
     async def test_buffer_wrap(self):
         """Test capture with more heaps than buffer slots, to check that it handles
         wrapping around the end of the buffer.
@@ -960,16 +976,7 @@ class TestCalDeviceServer(asynctest.TestCase):
         await self.make_request('capture-init', 'cb')
         # Wait until all the heaps have been delivered, timing out eventually.
         # This will take a while because it needs to allow the pipeline to run.
-        for i in range(240):
-            await asyncio.sleep(1)
-            heaps = await self.get_sensor('input-heaps-total')
-            total_heaps = sum(int(x) for x in heaps)
-            if total_heaps == n_times * self.n_substreams:
-                print('all heaps received')
-                break
-            print('waiting {} ({}/{} received)'.format(i, total_heaps, n_times * self.n_substreams))
-        else:
-            raise RuntimeError('Timed out waiting for the heaps to be received')
+        await self.wait_for_heaps(n_times * self.n_substreams, 240)
         for stream in self.l0_streams.values():
             stream.send_heap(self.ig.get_end())
         await self.shutdown_servers(60)
@@ -1079,38 +1086,87 @@ class TestCalDeviceServer(asynctest.TestCase):
         np.testing.assert_allclose(expected[1, 100], actual[1, 100], rtol=1e-4)
         np.testing.assert_allclose(expected, actual, rtol=1e-4)
 
+    async def wait_for_sensor(self, sensor, value, timeout):
+        # Wait timeout seconds for for sensor to have value
+        for i in range(timeout):
+            await asyncio.sleep(1)
+            rw = await self.get_sensor(sensor)
+            if rw == value:
+                break
+        else:
+            raise RuntimeError('Timed out waiting for %s to be %s' % (sensor, value))
+
     async def test_reset_solution_stores(self):
         """Test that the solution stores are reset between calls to capture_init"""
         n_times = 5
-        int_time = self.telstate_l0['int_time']
-        target = ('FluxC, radec delaycal bpcal gaincal, 13:31:08.29, +30:30:33.0, '
+        start_time = self.telstate.sdp_l0test_sync_time + 100.
+        end_time = start_time + n_times * self.telstate.sdp_l0test_int_time
+        target = ('J1331+3030, radec delaycal bpcal gaincal, 13:31:08.29, +30:30:33.0, '
                   '(0 50e3 0.1823 1.4757 -0.4739 0.0336)')
         self.telstate.add('cbf_target', target, ts=0.01)
         heaps = self.prepare_heaps(None, n_times)
         for endpoint, heap in heaps:
             self.l0_streams[endpoint].send_heap(heap)
         await self.make_request('capture-init', 'cb')
+        await self.wait_for_heaps(n_times * self.n_substreams, 240)
         for stream in self.l0_streams.values():
             stream.send_heap(self.ig.get_end())
         await self.make_request('capture-done')
-        # Wait for pipeline to finish which is after
-        # the reports have been written.
-        for i in range(240):
-            await asyncio.sleep(1)
-            rw = await self.get_sensor('reports-written')
-            if rw == [b'1'] * self.n_servers:
-                break
-        # The print is just to check that I have solution stores at this point
-        # Later I'll add tests here.
-        print(self.servers[0].server.pipeline.solution_stores)
-        await asyncio.sleep(1)
-        # Restart with a new set of heaps
+        # The pipeline has finished running when 'reports-written' increments
+        await self.wait_for_sensor('reports-written', [b'1'] * self.n_servers, 240)
+
+        # Check that the solution stores have the solutions for the expected target
+        ss = [serv.server.pipeline.solution_stores for serv in self.servers]
+        for serv_store in ss:
+            assert_equal(serv_store['B'].latest.target, 'J1331+3030')
+            assert_equal(serv_store['K'].latest.target, 'J1331+3030')
+            assert_true(serv_store['G'].has_target('J1331+3030'))
+            assert_true(serv_store['G_FLUX'].has_target('J1331+3030'))
+
+        # Refresh ItemGroup and send it to servers.
+        self.ig = spead2.send.ItemGroup()
+        self.add_items(self.ig)
+        for endpoint in self.l0_endpoints:
+            self.l0_streams[endpoint].send_heap(self.ig.get_heap(descriptors='all'))
+
+        # Set up a new capture block in telstate
+        self.populate_telstate_cb(self.telstate, 'cb2')
+
+        # A new target for a new CB
+        # Only use gaincal tag so we can check the stores have been reset
+        target = ('J1331+3030_2, radec gaincal, 13:31:08.29, +30:30:33.0, '
+                  '(0 50e3 0.1823 1.4757 -0.4739 0.0336)')
+        self.telstate.add('cbf_target', target, ts=0.02)
         heaps = self.prepare_heaps(None, n_times)
         for endpoint, heap in heaps:
             self.l0_streams[endpoint].send_heap(heap)
         await self.make_request('capture-init', 'cb2')
+        await self.wait_for_heaps(n_times * self.n_substreams, 240)
         for stream in self.l0_streams.values():
             stream.send_heap(self.ig.get_end())
+        # The pipeline has finished running when 'reports-written' increments
+        await self.wait_for_sensor('reports-written', [b'2'] * self.n_servers, 240)
+
+        # Check the solution stores only contain solutions from the new CB
+        ss = [serv.server.pipeline.solution_stores for serv in self.servers]
+        for serv_store in ss:
+            assert_is(serv_store['B'].latest, None)
+            assert_is(serv_store['K'].latest, None)
+            assert_true(serv_store['G'].has_target('J1331+3030_2'))
+            assert_false(serv_store['G'].has_target('J1331+3030'))
+            # There should now be no values in the G_FLUX store for this CB
+            G_FLUX = serv_store['G_FLUX'].get_range(start_time, end_time)
+            assert_equal(G_FLUX.values.size, 0)
+
+        # Check that 'cb' has 'measured_flux' in telstate for 'J1331+3030' only
+        telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
+        assert_true('J1331+3030' in telstate_cb_cal.get('measured_flux'))
+        assert_true('J1331+3030_2' not in telstate_cb_cal.get('measured_flux'))
+
+        # Check that 'cb2' has no 'measured_flux' targets in telstate
+        telstate_cb2_cal = control.make_telstate_cb(self.telstate_cal, 'cb2')
+        assert_equal(telstate_cb2_cal.get('measured_flux'), {})
+
         await self.shutdown_servers(180)
 
     async def test_pipeline_exception(self):


### PR DESCRIPTION
Reset the solution stores whenever `Accumulator.capture_init()` is called.

This is done using an `ObservationStartEvent` which is added to
`accum_pipeline_queue`. Pipeline now catches an `ObservationStartEvent`
and calls `_reset_solution_stores()`.