### PR TITLE
Add a computed parameter that toggles solution store reset.

### DIFF
--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1136,8 +1136,9 @@ class Pipeline(Task):
                 logger.info('waiting for next event (%s)', self.name)
                 event = self.accum_pipeline_queue.get()
                 if isinstance(event, ObservationStartEvent):
-                    logger.info('Resetting solution stores')
-                    self._reset_solution_stores()
+                    if self.parameters['reset_solution_stores']:
+                        logger.info('Resetting solution stores')
+                        self._reset_solution_stores()
                 elif isinstance(event, BufferReadyEvent):
                     logger.info('buffer with %d slots acquired by %s',
                                 len(event.slots), self.name)

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -141,7 +141,9 @@ COMPUTED_PARAMETERS = [
     Parameter('product_B_parts', 'number of separate keys forming bandpass solution', int,
               telstate=True),
     Parameter('servers', 'number of parallel servers', int),
-    Parameter('server_id', 'identity of this server (zero-based)', int)
+    Parameter('server_id', 'identity of this server (zero-based)', int),
+    Parameter('reset_solution_stores', 'reset the solution stores between capture blocks',
+              bool, telstate=True)
 ]
 
 
@@ -233,6 +235,7 @@ def finalise_parameters(parameters, telstate_l0, servers, server_id, rfi_filenam
     parameters['channel_slice'] = channel_slice
     parameters['servers'] = servers
     parameters['server_id'] = server_id
+    parameters['reset_solution_stores'] = True
 
     baselines = telstate_l0['bls_ordering']
     ants = set()

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -1103,6 +1103,9 @@ class TestCalDeviceServer(asynctest.TestCase):
 
     async def test_reset_solution_stores(self):
         """Test that the solution stores are reset between calls to capture_init"""
+        # Force pipeline to reset the solution stores
+        for serv in self.servers:
+            serv.server.pipeline.parameters['reset_solution_stores'] = True
         n_times = 5
         start_time = self.telstate.sdp_l0test_sync_time + 100.
         end_time = start_time + n_times * self.telstate.sdp_l0test_int_time


### PR DESCRIPTION
@ludwigschwardt this makes the change as we discussed. I've checked and the parameter ends up in telstate as expected.

At the moment I've hard-coded it to be True in `finalise_parameters`. We could make its value come from somewhere else, either a command-line argument or inside the parameter files.

Let me know what you think.