### PR TITLE
Improve the models plotted in the cal report

### DIFF
--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -780,6 +780,12 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
 
             s.apply_inplace(solns_to_apply)
 
+            # save average model for report, if a model exists
+            if s.model is not None:
+                chan_sample = s.nchan//1024
+                model_average = np.average(s.model, axis=(0, -2, -1))[::chan_sample]
+                av_corr[target_name + '_model'].insert(0, model_average)
+
             # TARGET
             if 'target' in taglist:
                 # accumulate list of target scans to be streamed to L1

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -340,9 +340,11 @@ class Scan:
 
         g_freqs = self.channel_freqs[bchan:echan]
 
+        # initialise model, even if it is not used in solving for g
+        # so it can be included in the report
+        self._init_model()
         if use_model:
-            # initialise and apply model, if this scan target has an associated model
-            self._init_model()
+            # apply model if required
             fitvis = self._get_solver_model(modvis, chan_select=chan_slice)
         else:
             fitvis = modvis[chan_slice]


### PR DESCRIPTION
Previously the report only reported and plotted the flux from the first
component (assumed to be dominant in the field) in the calibrator field
model.

This PR updates this to plot the average (across baseline and time) of
all the components in the calibrator field model.

To achieve this the pipeline saves the averaged model in the corrected
data dictionary which is passed to the report writer at the end of the
observation. This allows the model to be calculated only once, rather
than having to recalculate it from scratch in the report writer.

In the split cal case, the report writer for the server
containing the relevant channels for the flux calculation (ie the g_gchan
to g_echan interval) calculates the average flux for the interval and
stores it in telstate with the key 'target_name_model_flux'.