### PR TITLE
Increase timeouts for failing tests

### DIFF
--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -1007,7 +1007,7 @@ class TestCalDeviceServer(asynctest.TestCase):
         await self.wait_for_heaps(n_times * self.n_substreams, 240)
         for stream in self.l0_streams.values():
             stream.send_heap(self.ig.get_end())
-        await self.shutdown_servers(60)
+        await self.shutdown_servers(90)
 
     async def test_out_of_order(self):
         """A heap received from the past should be processed (if possible).
@@ -1103,7 +1103,7 @@ class TestCalDeviceServer(asynctest.TestCase):
             self.l0_streams[endpoint].send_heap(heap)
         await self.make_request('capture-init', 'cb')
         await asyncio.sleep(1)
-        await self.make_request('shutdown', timeout=60)
+        await self.make_request('shutdown', timeout=90)
         # Reassemble the buffered data from the individual servers
         actual = np.zeros_like(expected)
         for server in self.servers:


### PR DESCRIPTION
Periodically some of the tests of `control.py` are taking longer to
run than the timeout on the shutdown requests. This causes the tests to
fail because the report writer tries to finish writing the report to a
directory that has been deleted during cleanup.

I'm increasing the timeouts to reduce the likelihood of these tests
failing.