### PR TITLE
Choose a new reference antenna if necessary

### DIFF
--- a/katsdpcal/calprocs.py
+++ b/katsdpcal/calprocs.py
@@ -346,8 +346,8 @@ def best_refant(data, corrprod_lookup, chans):
 
     Returns
     -------
-    best_refant : int
-        Index of antenna with the maximum median of PNR over all baselines
+    best_refant : :class:`np.ndarray`
+        Array of indices of antennas in decreasing order of median of PNR over all baselines
     """
     # Detect position of fft peak
     ft_vis = scipy.fftpack.fft(data, axis=0)
@@ -374,7 +374,7 @@ def best_refant(data, corrprod_lookup, chans):
         # due to https://github.com/numpy/numpy/pull/13715
         pnr = (peak[..., mask] - mean[..., mask]) / std[..., mask]
         med_pnr_ants[a] = np.median(pnr)
-    return np.argmax(med_pnr_ants)
+    return np.argsort(med_pnr_ants)[::-1]
 
 
 def g_fit(data, weights, corrprod_lookup,  g0=None, refant=0, **kwargs):

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1080,6 +1080,10 @@ class Pipeline(Task):
             'G_FLUX': solutions.CalSolutionStore('G')
         }
 
+    def _reset_refant(self):
+        self.parameters['refant_index_prev'] = self.parameters['refant_index']
+        self.parameters['refant_index'] = None
+
     def get_sensors(self):
         return [
             aiokatcp.Sensor(
@@ -1145,6 +1149,7 @@ class Pipeline(Task):
                 logger.info('waiting for next event (%s)', self.name)
                 event = self.accum_pipeline_queue.get()
                 if isinstance(event, ObservationStartEvent):
+                    self._reset_refant()
                     if self.parameters['reset_solution_stores']:
                         logger.info('Resetting solution stores')
                         self._reset_solution_stores()

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -409,10 +409,8 @@ def set_refant(s, ts, parameters, sensors):
 
     # update parameters, telstate and scan with new refant
     best_refant = parameters['antenna_names'][best_refant_index]
-    parameters['refant_index'] = best_refant_index
-    parameters['refant'] = best_refant
-    s.refant = best_refant_index
-    ts['refant'] = parameters['refant']
+    parameters['refant_index'] = s.refant = best_refant_index
+    parameters['refant'] = ts['refant'] = best_refant
 
     # update sensors if refant has changed
     if best_refant_index != parameters['refant_index_prev']:

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -385,6 +385,42 @@ def shared_B_interp_nans(telstate, parameters, b_soln, st, et):
     return solutions.CalSolution('B', b_interp, b_soln.time, b_soln.target)
 
 
+def set_refant(s, ts, parameters, sensors):
+    """Select and update the reference antenna.
+
+    Update the reference antenna in all relevant stores including sensors,
+    parameters, telstate and scan attributes.
+
+    Parameters
+    ----------
+    s : :class:`~.Scan`
+        scan of data to select refant
+    ts : :class:`katsdptelstate.TelescopeState`
+        telstate used in solver and updated to new refant
+    parameters : dict
+        calibration parameters used by solver and updated to new refant
+    sensors : dict
+        Sensors available in the calling parent
+    """
+    # select a new refant if the old one is flagged
+    best_refant_index = shared_solve(ts, parameters, None,
+                                     parameters['k_bchan'], parameters['k_echan'],
+                                     s.refant_find, refant_index=parameters['refant_index_prev'])
+
+    # update parameters, telstate and scan with new refant
+    best_refant = parameters['antenna_names'][best_refant_index]
+    parameters['refant_index'] = best_refant_index
+    parameters['refant'] = best_refant
+    s.refant = best_refant_index
+    ts['refant'] = parameters['refant']
+
+    # update sensors if refant has changed
+    if best_refant_index != parameters['refant_index_prev']:
+        logger.info('Reference antenna set to %s', parameters['refant'])
+        sensors['pipeline-reference-antenna'].set_value(
+            parameters['refant'], timestamp=s.timestamps[0])
+
+
 def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
     """Pipeline calibration.
 
@@ -514,21 +550,10 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
             logger.info('Calibrator flagging')
             s.rfi(calib_flagger, parameters['rfi_mask'], sensors=sensors)
 
-            # Set a reference antenna if one isn't already set
+            # Set a reference antenna for this cbid if one isn't already set
             if s.refant is None:
-                best_refant_index = shared_solve(ts, parameters, None,
-                                                 parameters['k_bchan'], parameters['k_echan'],
-                                                 s.refant_find)
-                parameters['refant_index'] = best_refant_index
-                parameters['refant'] = parameters['antenna_names'][best_refant_index]
-                logger.info('Reference antenna set to %s', parameters['refant'])
-                sensors['pipeline-reference-antenna'].set_value(
-                    parameters['refant'], timestamp=s.timestamps[0])
-                s.refant = best_refant_index
+                set_refant(s, ts, parameters, sensors)
 
-            # Add the reference antenna to telstate for each new cbid
-            if 'refant' not in ts:
-                ts['refant'] = parameters['refant']
         # run_t0 = time.time()
         # perform calibration as appropriate, from scan intent tags:
 

--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -1594,13 +1594,11 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
             cal_rst.writeln()
 
             # Obtain reference antenna selected by the pipeline
-            refant_index = parameters['refant_index']
-            if refant_index is None:
-                refant_name = ts.get('refant')
-                if refant_name is not None:
-                    refant_index = parameters['antenna_names'].index(refant_name)
-                    parameters['refant'] = refant_name
-                    parameters['refant_index'] = refant_index
+            refant_name = ts.get('refant')
+            if refant_name is not None:
+                refant_index = parameters['antenna_names'].index(refant_name)
+                parameters['refant'] = refant_name
+                parameters['refant_index'] = refant_index
 
             antennas = parameters['antennas']
             if av_corr:

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -277,9 +277,9 @@ class Scan:
             refant_bls = np.where((self.cross_ant.bls_lookup[:, 0] == refant_index) ^
                                   (self.cross_ant.bls_lookup[:, 1] == refant_index))[0]
             total_size = np.multiply.reduce(
-                self.cross_ant.pb.auto_pol.vis[..., refant_bls].shape) / 100.
+                self.cross_ant.pb.auto_pol.vis[..., refant_bls].shape)
             flags = da.sum(calprocs.asbool(self.cross_ant.pb.auto_pol.flags[..., refant_bls]))
-            flag_frac = (flags / total_size).compute()
+            flag_frac = 100. * (flags / total_size).compute()
 
             if flag_frac < 80.0:
                 return refant_index

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -255,46 +255,71 @@ class Scan:
 
     # ---------------------------------------------------------------------------------------------
     @logsolutiontime
-    def refant_find(self, bchan=1, echan=None, chan_sample=1):
+    def refant_find(self, bchan=1, echan=None, chan_sample=1, refant_index=None):
         """Find a good reference antenna candidate.
+
+        If a refant_index is supplied, check its flag fraction.
+        If > 80% of data is flagged, select a new refant_index, else return same index
 
         Parameters
         ----------
         bchan : start channel for fit, int, optional
         echan : end channel for fit, int, optional
         chan_sample : channel sampling to use in delay fit, optional
+        refant_index : int or None, optional
 
         Returns
         -------
         refant_index : int
             index of preferred refant
         """
-        modvis = self.cross_ant.tf.auto_pol.vis
-
-        # determine channel range for fit
-        chan_slice = np.s_[:, bchan:echan, :, :]
-        # use specified channel range for frequencies
-        k_freqs = self.channel_freqs[bchan:echan]
-
-        # initialise model, if this scan target has an associated model
-        self._init_model()
-        # for delay case, only apply case C full visibility model (other models don't impact delay)
-        if self.model is None:
-            fitvis = modvis[chan_slice]
-        elif self.model.shape[-1] == 1:
-            fitvis = modvis[chan_slice]
+        if refant_index:
+            refant_bls = np.where((self.cross_ant.bls_lookup[:, 0] == refant_index) ^
+                                  (self.cross_ant.bls_lookup[:, 1] == refant_index))[0]
+            total_size = np.multiply.reduce(
+                self.cross_ant.pb.auto_pol.vis[..., refant_bls].shape) / 100.
+            flags = da.sum(calprocs.asbool(self.cross_ant.pb.auto_pol.flags[..., refant_bls]))
+            flag_frac = (flags / total_size).compute()
+            logger.info('Flag fraction on refant is %.3f%%', flag_frac)
         else:
-            fitvis = self._get_solver_model(modvis, chan_select=chan_slice)
-        # average over all time, for specified channel range (no averaging over channel)
-        ave_vis = calprocs_dask.wavg(
-            fitvis,
-            self.cross_ant.tf.auto_pol.flags[chan_slice],
-            self.cross_ant.tf.auto_pol.weights[chan_slice])
+            flag_frac = 100.0
 
-        # fit for delay
-        ave_vis = ave_vis.compute()
-        refant_index = calprocs.best_refant(ave_vis, self.cross_ant.bls_lookup, k_freqs)
-        return refant_index
+        if flag_frac < 80.0:
+            return refant_index
+        else:
+            if refant_index:
+                logger.info('Flag fraction on refant is > 80%% (%.3f%%),'
+                            ' selecting a new refant', flag_frac)
+
+            modvis = self.cross_ant.tf.auto_pol.vis
+            # determine channel range for fit
+            chan_slice = np.s_[:, bchan:echan, :, :]
+            # use specified channel range for frequencies
+            k_freqs = self.channel_freqs[bchan:echan]
+
+            # initialise model, if this scan target has an associated model
+            self._init_model()
+            # for delay case, only apply case C full visibility model
+            # (other models don't impact delay)
+            if self.model is None:
+                fitvis = modvis[chan_slice]
+            elif self.model.shape[-1] == 1:
+                fitvis = modvis[chan_slice]
+            else:
+                fitvis = self._get_solver_model(modvis, chan_select=chan_slice)
+            # average over all time, for specified channel range (no averaging over channel)
+            ave_vis = calprocs_dask.wavg(
+                fitvis,
+                self.cross_ant.tf.auto_pol.flags[chan_slice],
+                self.cross_ant.tf.auto_pol.weights[chan_slice])
+
+            # fit for delay
+            ave_vis = ave_vis.compute()
+            refant_order = list(calprocs.best_refant(ave_vis, self.cross_ant.bls_lookup, k_freqs))
+            # ensure we don't pick the old, flagged antenna
+            if refant_index:
+                refant_order.remove(refant_index)
+            return refant_order[0]
 
     # ---------------------------------------------------------------------------------------------
     # Calibration solution functions

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -866,7 +866,8 @@ class TestCalDeviceServer(asynctest.TestCase):
 
     async def test_set_refant(self):
         """Tests the capture with a noisy antenna, and checks that the reference antenna is
-         not set to the noisiest antenna.
+         not set to the noisiest antenna. Also checks that a new refant in selected for a new
+         capture block if the old one is flagged
         """
         ts = 100.0
         n_times = 25
@@ -907,15 +908,59 @@ class TestCalDeviceServer(asynctest.TestCase):
         for endpoint, heap in heaps:
             self.l0_streams[endpoint].send_heap(heap)
         await self.make_request('capture-init', 'cb')
-        await asyncio.sleep(1)
+        await self.wait_for_heaps(n_times * self.n_substreams, 60)
         for stream in self.l0_streams.values():
             stream.send_heap(self.ig.get_end())
-        await self.shutdown_servers(180)
-        await self.assert_sensor_value('accumulator-capture-active', 0)
+        await self.make_request('capture-done')
+        # The pipeline has finished running when 'reports-written' increments
+        await self.wait_for_sensor('reports-written', [b'1'] * self.n_servers, 240)
+
+        # Check the pipeline did not select the noisy antenna as the refant
         telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
         refant_name = telstate_cb_cal['refant']
         assert_not_equal(self.antennas[worst_index], refant_name)
         await self.assert_sensor_value('pipeline-reference-antenna', refant_name.encode())
+
+        # Refresh ItemGroup and send it to servers.
+        self.init_item_group()
+        # Set up a new capture block in telstate
+        self.populate_telstate_cb(self.telstate, 'cb2')
+        # A new target for a new CB
+        self.telstate.add('cbf_target', self.telstate.cbf_target, ts=0.02)
+
+        # flag the refant selected in the previous capture block
+        bls_ordering = self.telstate.sdp_l0test_bls_ordering
+        ant1 = [self.antennas.index(b[0][:-1]) for b in bls_ordering]
+        ant2 = [self.antennas.index(b[1][:-1]) for b in bls_ordering]
+        refant_index_cb = self.antennas.index(refant_name)
+        flag_refant = np.where((np.array(ant1) == refant_index_cb) |
+                               (np.array(ant2) == refant_index_cb), 1, 0).astype(np.uint8)
+        flag_refant = np.broadcast_to(flag_refant, flags.shape)
+
+        heaps = self.prepare_vis_heaps(n_times, rs, ts, vis, flag_refant, weights, weights_channel)
+        for endpoint, heap in heaps:
+            self.l0_streams[endpoint].send_heap(heap)
+        await self.make_request('capture-init', 'cb2')
+        await self.wait_for_heaps(n_times * self.n_substreams, 60)
+        for stream in self.l0_streams.values():
+            stream.send_heap(self.ig.get_end())
+
+        # The pipeline has finished running when 'reports-written' increments
+        await self.wait_for_sensor('reports-written', [b'2'] * self.n_servers, 240)
+
+        # Check the pipeline did not select the now flagged antenna as the refant
+        telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb2')
+        refant_name = telstate_cb_cal['refant']
+        refant_index_cb2 = self.antennas.index(refant_name)
+        assert_not_equal(self.antennas[refant_index_cb], refant_name)
+        await self.assert_sensor_value('pipeline-reference-antenna', refant_name.encode())
+        # Check the pipeline params have been updated to reflect the current and past refants
+        pp = [serv.server.pipeline.parameters for serv in self.servers]
+        for params in pp:
+            assert_equal(params['refant_index_prev'], refant_index_cb)
+            assert_equal(params['refant_index'], refant_index_cb2)
+
+        await self.shutdown_servers(180)
 
     def prepare_heaps(self, rs, n_times,
                       vis=None, weights=None, weights_channel=None, flags=None):

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -866,7 +866,7 @@ class TestCalDeviceServer(asynctest.TestCase):
 
     async def test_set_refant(self):
         """Tests the capture with a noisy antenna, and checks that the reference antenna is
-         not set to the noisiest antenna. Also checks that a new refant in selected for a new
+         not set to the noisiest antenna. Also checks that a new refant is selected for a new
          capture block if the old one is flagged
         """
         ts = 100.0


### PR DESCRIPTION
This is to address https://skaafrica.atlassian.net/browse/SR-1228.
If the reference antenna selected by the pipeline at the beginning of
the subarray is flagged for any reason it results in NaN solutions. This
commit allows the pipeline to select a new refant at the start of a
new capture-block if the previously selected refant is flagged.

This commit allows the pipeline to select a new refant if:
* one hasn't already been selected (e.g at the start of the subarray)
* the current refant has a flag fraction >80%

This PR goes to some effort to ensure that a new reference antenna isn't selected every capture block, 
and that a change only takes place if the old reference antenna is flagged. This isn't strictly necessary
as the capture-block solutions should be fairly independent of each other.  I've kept this feature with an eye
to the future where we hopefully be able to change the reference antenna even within a capture block, in this case it 
will be desirable to avoid changing the reference antenna unless absolutely necessary. 