### PR TITLE
Support multi-frequency setups for S-band

### DIFF
--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S.txt
@@ -5,7 +5,7 @@ k_solint : 5.0                       # nominal pre-k g solution interval, second
 k_chan_sample : 1                    # channel sampling for pre-K BP soln
 k_bfreq : 2010.60, 2517.60, 2876.46  # start frequency of first channel for K fit per subband, MHz
 k_efreq : 2096.08, 2603.40, 2961.90  # end frequency of last channel for K fit per subband , MHz
-band_start_freq : 1750.00, 1968.75, 2406.25     # start frequency range for per subband parameters
+subband_bfreq : 1750.00, 1968.75, 2406.25     # start frequency range for per subband parameters
 kcross_chanave : 1                   # number of channels to average together to kcross solution
 
 # bandpass calibration

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S.txt
@@ -3,8 +3,9 @@
 # delay calibration
 k_solint : 5.0                       # nominal pre-k g solution interval, seconds
 k_chan_sample : 1                    # channel sampling for pre-K BP soln
-k_bfreq : 3105.65                    # start frequency of first channel for K fit, MHz
-k_efreq : 3148.38                    # end frequency of last channel for K fit, MHz
+k_bfreq : 2010.60, 2517.60, 2876.46  # start frequency of first channel for K fit, MHz
+k_efreq : 2096.08, 2603.40, 2961.90  # end frequency of last channel for K fit, MHz
+band_start_freq : 1750.00, 1968.75, 2406.25     #start frequency range for per band parameters
 kcross_chanave : 1                   # number of channels to average together to kcross solution
 
 # bandpass calibration

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S.txt
@@ -3,9 +3,9 @@
 # delay calibration
 k_solint : 5.0                       # nominal pre-k g solution interval, seconds
 k_chan_sample : 1                    # channel sampling for pre-K BP soln
-k_bfreq : 2010.60, 2517.60, 2876.46  # start frequency of first channel for K fit, MHz
-k_efreq : 2096.08, 2603.40, 2961.90  # end frequency of last channel for K fit, MHz
-band_start_freq : 1750.00, 1968.75, 2406.25     #start frequency range for per band parameters
+k_bfreq : 2010.60, 2517.60, 2876.46  # start frequency of first channel for K fit per subband, MHz
+k_efreq : 2096.08, 2603.40, 2961.90  # end frequency of last channel for K fit per subband , MHz
+band_start_freq : 1750.00, 1968.75, 2406.25     # start frequency range for per subband parameters
 kcross_chanave : 1                   # number of channels to average together to kcross solution
 
 # bandpass calibration
@@ -13,8 +13,8 @@ bp_solint : 5.0                      # nominal pre-bp g solution interval, secon
 
 # gain calibration
 g_solint: 5.0                        # nominal g solution interval, seconds
-g_bfreq : 3105.65                    # start frequency of first channel for g fit, MHz
-g_efreq : 3148.38                    # end frequency of last channel for g fit, MHz
+g_bfreq : 2010.60, 2517.60, 2876.46  # start frequency of first channel for g fit per subband, MHz
+g_efreq : 2096.08, 2603.40, 2961.90  # end frequency of last channel for g fit per subband, MHz
 
 # Flagging
 rfi_calib_nsigma : 4.5               # Number of sigma to reject outliers for calibrators

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -90,8 +90,6 @@ def comma_list(type_):
         if value == '':
             return []
         parts = value.split(',')
-        if len(parts) == 1:
-            return type_(parts[0])
         return [type_(part.strip()) for part in parts]
 
     return convert
@@ -142,12 +140,12 @@ USER_PARAMS_CHANS = [
 
 # Parameters that the user can set directly, in units of Hz/MHz
 USER_PARAMS_FREQS = [
-    Parameter('k_bfreq', 'start frequency for k fit per band, (MHz)', comma_list(float)),
-    Parameter('k_efreq', 'stop frequency for k fit per band, (MHz)', comma_list(float)),
-    Parameter('g_bfreq', 'start frequency for g fit per band, (MHz)', comma_list(float)),
-    Parameter('g_efreq', 'stop frequency for g fit per band, (MHz)', comma_list(float)),
+    Parameter('k_bfreq', 'start frequency for k fit per subband, (MHz)', comma_list(float)),
+    Parameter('k_efreq', 'stop frequency for k fit per subband, (MHz)', comma_list(float)),
+    Parameter('g_bfreq', 'start frequency for g fit per subband, (MHz)', comma_list(float)),
+    Parameter('g_efreq', 'stop frequency for g fit per subband, (MHz)', comma_list(float)),
     Parameter('band_start_freq', 'start frequency range corresponding to parameters'
-              ' supplied per frequency band, (MHz)', comma_list(float), telstate=False),
+              ' supplied per frequency subband, (MHz)', comma_list(float), telstate=False),
     Parameter('rfi_average_hz', 'amount to average in frequency before flagging, (Hz)', float),
     Parameter('rfi_windows_post_average',
               'size of windows for SumThreshold on frequency averaged data, (channels)',
@@ -433,9 +431,8 @@ def parameters_for_freq(parameters, channel_freqs):
     """
     for key in parameters.keys():
         if key.endswith('_efreq') or key.endswith('_bfreq'):
-            if type(parameters[key]) == list:
+            if len(parameters[key]) > 1:
                 try:
-                    parameters['band_start_freq']
                     band_idx = max([i for i, s_freq in enumerate(parameters['band_start_freq'])
                                     if min(channel_freqs/1e6) >= s_freq])
                     parameters[key] = parameters[key][band_idx]
@@ -443,6 +440,9 @@ def parameters_for_freq(parameters, channel_freqs):
                     logger.error("If '%s' is a list of values,"
                                  " a 'band_start_freq' parameter is required", key)
                     raise
+            elif len(parameters[key]) == 1:
+                parameters[key] = float(parameters[key][0])
+
     # remove parameter as it is no longer required
     if 'band_start_freq' in parameters:
         del parameters['band_start_freq']

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -144,7 +144,7 @@ USER_PARAMS_FREQS = [
     Parameter('k_efreq', 'stop frequency for k fit per subband, (MHz)', comma_list(float)),
     Parameter('g_bfreq', 'start frequency for g fit per subband, (MHz)', comma_list(float)),
     Parameter('g_efreq', 'stop frequency for g fit per subband, (MHz)', comma_list(float)),
-    Parameter('band_start_freq', 'start frequency range corresponding to parameters'
+    Parameter('subband_bfreq', 'start frequency range corresponding to parameters'
               ' supplied per frequency subband, (MHz)', comma_list(float), telstate=False),
     Parameter('rfi_average_hz', 'amount to average in frequency before flagging, (Hz)', float),
     Parameter('rfi_windows_post_average',
@@ -429,23 +429,24 @@ def parameters_for_freq(parameters, channel_freqs):
     If solution interval parameters (e.g. k_bfreq) are supplied as a list,
     then select the appropriate value for the frequency setup of the observation
     """
-    for key in parameters.keys():
-        if key.endswith('_efreq') or key.endswith('_bfreq'):
+    subband_keys = ['g_bfreq', 'g_efreq', 'k_bfreq', 'k_efreq']
+    for key in subband_keys:
+        if key in parameters and parameters[key] != []:
             if len(parameters[key]) > 1:
                 try:
-                    band_idx = max([i for i, s_freq in enumerate(parameters['band_start_freq'])
-                                    if min(channel_freqs/1e6) >= s_freq])
-                    parameters[key] = parameters[key][band_idx]
+                    subband_idx = max([i for i, s_freq in enumerate(parameters['subband_bfreq'])
+                                       if min(channel_freqs/1e6) >= s_freq])
+                    parameters[key] = parameters[key][subband_idx]
                 except KeyError:
                     logger.error("If '%s' is a list of values,"
-                                 " a 'band_start_freq' parameter is required", key)
+                                 " a 'subband_bfreq' parameter is required", key)
                     raise
             elif len(parameters[key]) == 1:
                 parameters[key] = float(parameters[key][0])
 
     # remove parameter as it is no longer required
-    if 'band_start_freq' in parameters:
-        del parameters['band_start_freq']
+    if 'subband_bfreq' in parameters:
+        del parameters['subband_bfreq']
 
 
 def parameters_to_telstate(parameters, telstate_cal, l0_name):

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -431,18 +431,19 @@ def parameters_for_freq(parameters, channel_freqs):
     """
     subband_keys = ['g_bfreq', 'g_efreq', 'k_bfreq', 'k_efreq']
     for key in subband_keys:
-        if key in parameters and parameters[key] != []:
-            if len(parameters[key]) > 1:
-                try:
-                    subband_idx = max([i for i, s_freq in enumerate(parameters['subband_bfreq'])
-                                       if min(channel_freqs/1e6) >= s_freq])
-                    parameters[key] = parameters[key][subband_idx]
-                except KeyError:
-                    logger.error("If '%s' is a list of values,"
-                                 " a 'subband_bfreq' parameter is required", key)
-                    raise
-            elif len(parameters[key]) == 1:
-                parameters[key] = float(parameters[key][0])
+        if key not in parameters:
+            continue
+        if len(parameters[key]) > 1:
+            try:
+                subband_idx = max([i for i, s_freq in enumerate(parameters['subband_bfreq'])
+                                   if min(channel_freqs/1e6) >= s_freq])
+                parameters[key] = parameters[key][subband_idx]
+            except KeyError:
+                logger.error("If '%s' is a list of values,"
+                             " a 'subband_bfreq' parameter is required", key)
+                raise
+        elif len(parameters[key]) == 1:
+            parameters[key] = float(parameters[key][0])
 
     # remove parameter as it is no longer required
     if 'subband_bfreq' in parameters:

--- a/katsdpcal/test/test_pipelineprocs.py
+++ b/katsdpcal/test/test_pipelineprocs.py
@@ -205,6 +205,14 @@ class TestFinaliseParameters(unittest.TestCase):
         with self.assertRaises(ValueError):
             pipelineprocs.finalise_parameters(self.parameters, self.telstate_l0, 4, 2)
 
+    def test_list_parameters(self):
+        self.parameters['k_bfreq'] = [1112.1, 1326.2]
+        self.parameters['k_efreq'] = [1154.012, 1368.012]
+        self.parameters['band_start_freq'] = [642.0, 856.0]
+        parameters = pipelineprocs.finalise_parameters(self.parameters, self.telstate_l0, 4, 2)
+        self.assertEqual(202, parameters['k_bchan'])
+        self.assertEqual(402, parameters['k_echan'])
+
 
 class TestCreateModel(unittest.TestCase):
     """Tests for 'katsdpcal.pipelineprocs.get_model'"""

--- a/katsdpcal/test/test_pipelineprocs.py
+++ b/katsdpcal/test/test_pipelineprocs.py
@@ -208,7 +208,7 @@ class TestFinaliseParameters(unittest.TestCase):
     def test_list_parameters(self):
         self.parameters['k_bfreq'] = [1112.1, 1326.2]
         self.parameters['k_efreq'] = [1154.012, 1368.012]
-        self.parameters['band_start_freq'] = [642.0, 856.0]
+        self.parameters['subband_bfreq'] = [642.0, 856.0]
         parameters = pipelineprocs.finalise_parameters(self.parameters, self.telstate_l0, 4, 2)
         self.assertEqual(202, parameters['k_bchan'])
         self.assertEqual(402, parameters['k_echan'])

--- a/katsdpcal/test/test_pipelineprocs.py
+++ b/katsdpcal/test/test_pipelineprocs.py
@@ -91,13 +91,13 @@ class TestFinaliseParameters(unittest.TestCase):
         self.parameters = {
             'k_solint': 5.0,
             'k_chan_sample': 1,
-            'k_bfreq': 1326.200,
-            'k_efreq': 1368.012,
+            'k_bfreq': [1326.200],
+            'k_efreq': [1368.012],
             'kcross_chanave': 1,
             'bp_solint': 5.0,
             'g_solint': 5.0,
-            'g_bfreq': 1326.200,
-            'g_efreq': 1368.012,
+            'g_bfreq': [1326.200],
+            'g_efreq': [1368.012],
             'rfi_calib_nsigma': 4.5,
             'rfi_targ_nsigma': 7.0,
             'rfi_windows_post_average': [1, 2, 4, 8],
@@ -191,12 +191,12 @@ class TestFinaliseParameters(unittest.TestCase):
             pipelineprocs.finalise_parameters(self.parameters, self.telstate_l0, 4, 2)
 
     def test_bad_channel_range(self):
-        self.parameters['k_efreq'] = 1315765625  # chan 2200 in L-band 4K
+        self.parameters['k_efreq'] = [1315765625]  # chan 2200 in L-band 4K
         with self.assertRaises(ValueError):
             pipelineprocs.finalise_parameters(self.parameters, self.telstate_l0, 4, 2)
 
     def test_channel_range_spans_servers(self):
-        self.parameters['k_efreq'] = 1498208985  # chan 3073 in L-band 4K
+        self.parameters['k_efreq'] = [1498208985]  # chan 3073 in L-band 4K
         with self.assertRaises(ValueError):
             pipelineprocs.finalise_parameters(self.parameters, self.telstate_l0, 4, 2)
 


### PR DESCRIPTION
This is to address https://skaafrica.atlassian.net/browse/SPR1-463.
The cal pipeline uses a narrow range of frequencies (specified by e.g.
g_bfreq, g_efreq) to perform gain and delay calibration. These have
always been provided as a single float per band. S-band has multiple (5)
possible frequency setups across the full 1750 - 3500 MHz band, and a
single frequency range cannot be used for all 5 possible bands.

This modifies the pipeline to allow these parameters to be supplied as
either a list of a float. If a list is provided another parameter
('band_start_freq') is required, which provides a list of starting
 frequencies that correspond to the list of gain and delay calibration windows.