### PR TITLE
Use install_pinned to install requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="$PATH_PYTHON3" VIRTUAL_ENV="$VIRTUAL_ENV_PYTHON3"
 
 # Install python dependencies
 COPY requirements.txt /tmp/install/
-RUN install-requirements.py -d ~/docker-base/base-requirements.txt -r /tmp/install/requirements.txt
+RUN install_pinned.py -r /tmp/install/requirements.txt
 
 # Install the current package
 COPY . /tmp/install/katsdpcal

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,6 @@ katsdp.setDependencies([
     'ska-sa/katsdpservices/master',
     'ska-sa/katsdptelstate/master'])
 katsdp.standardBuild(
-    python3: true,
-    python2: false,
     docker_venv: true,
     push_external: true)
 katsdp.mail('sdpdev+katsdpcal@ska.ac.za')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "katversion"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,64 +1,25 @@
-appdirs                 # for katsdpsigproc
-aioconsole
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 aiokatcp
-aiomonitor
 async_timeout
 attrs
 bokeh
-certifi                 # for requests
-chardet                 # for requests
-cityhash                # for katdal
 click==7.0              # for distributed
 cloudpickle==1.3.0      # for distributed
-cycler                  # for matplotlib
 dask
-decorator               # for katsdpsigproc, aiokatcp
 distributed==2.12.0
 docutils
-ephem                   # for pyephem
-future                  # for katdal, katpoint
-h5py                    # for katdal
 heapdict==1.0.1         # for distributed
-idna                    # for requests
-importlib-metadata      # for jsonschema
-jinja2                  # for bokeh
 jsonschema
-katversion
-kiwisolver              # for matplotlib
-llvmlite                # for numba
-mako                    # for katsdpsigproc
-markupsafe              # for mako
 matplotlib
-msgpack                 # for distributed, katsdptelstate
-netifaces               # for katsdptelstate
 numba
 numpy
-packaging               # for bokeh
-pandas                  # for katsdpsigproc
-pillow                  # for bokeh
 psutil==5.7.0           # for distributed
-pyephem                 # for katpoint
-pygelf                  # for katsdpservices
-pyjwt                   # for katdal
-pyrsistent              # for jsonschema
-python-dateutil         # for pandas, matplotlib, bokeh
-python-lzf              # for katdal
-pytz                    # for pandas, matplotlib
-pyyaml                  # for distributed, bokeh
-rdbtools                # for katdal
-redis                   # for katsdptelstate
-requests                # for katdal
 scipy
 sortedcontainers
 spead2
 tblib==1.6.0            # for distributed
-terminaltables          # for aiomonitor
-toolz                   # for dask
-tornado                 # for distributed, bokeh
-typing_extensions       # for katsdpsigproc
-urllib3                 # for requests
 zict==2.0.0             # for distributed
-zipp                    # for importlib-metadata
 
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     platforms=["OS Independent"],
     keywords="kat kat7 meerkat ska",
     zip_safe=False,
-    setup_requires=["katversion"],
     python_requires=">=3.5",
     install_requires=[
         "numpy>=1.15", "scipy>=0.17", "numba>=0.19.0",

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
+-c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+
 asynctest
 coverage
 nose


### PR DESCRIPTION
requirements.txt gets a lot shorter as a result. Also add a
pyproject.toml to ensure that katversion is available at setup time, and
remove redundant lines from Jenkinsfile.

See SPR1-833.