### PR TITLE
Fix bogus claims of report directory already existing

### DIFF
--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1510,7 +1510,7 @@ class ReportWriter(Task):
         current_report_dir = report_dir + '-current'
         try:
             os.mkdir(current_report_dir)
-        except OSError:
+        except FileExistsError:
             logger.warning('Report directory %s already exists', current_report_dir)
 
         # create pipeline report


### PR DESCRIPTION
It would log this for any OSError on os.mkdir, possibly suppressing
other, more serious errors and logging bogus information.