### PR TITLE
Support multiple servers in the replayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ The simulator uses either an H5 or MS file as the data source.
 
 2. Run the h5 Telescope State simulator:
 
- > sim_ts.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\>
+       sim_ts.py --telstate 127.0.0.1:6379 --file <file.rdb/h5/ms>
 
 3. Run the pipeline controller:
 
- > run_cal.py --telstate 127.0.0.1:6379
+       run_cal.py --telstate 127.0.0.1:6379
 
 4. Run the h5 data stream:
 
- > sim_data_stream.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\>
+       sim_data_stream.py --telstate 127.0.0.1:6379 --file <file.rdb/h5/ms>
 
 You can pass `--max-scans` to restrict the number of scans to replay from a large file.
 
@@ -39,7 +39,7 @@ This additionally requires
 * tmux
 * tmuxp (0.8.1+)
 
- > run_katsdpcal_sim.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\> --max-scans=7 --keep-sessions
+      run_katsdpcal_sim.py --telstate 127.0.0.1:6379 --file <file.rdb/h5/ms> --max-scans=7 --keep-sessions
 
 The shortcut simulator runs each of the five commands above in separate tmux
 sessions, named redis, sim\_ts, pipeline and sim\_data respectively.
@@ -55,17 +55,17 @@ it can scale up to higher numbers.
 
 2. Run the Telescope State simulator:
 
- > sim_ts.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\> --substreams 2
+       sim_ts.py --telstate 127.0.0.1:6379 --file <file.rdb/h5/ms> --substreams 2
 
 3. Run the pipeline controller (in parallel):
 
- > run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
-     --servers 4 -p 2060 --server-id 1
- > run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
-     --servers 4 -p 2061 --server-id 2
+       run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
+         --servers 4 -p 2060 --server-id 1
+       run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
+         --servers 4 -p 2061 --server-id 2
 
 4. Run the h5 data stream:
 
- > sim_data_stream.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\> \
-     --l0-spead 239.102.254.0+1:7148 --l0-interface=lo \
-     --server localhost:2060,localhost:2061
+       sim_data_stream.py --telstate 127.0.0.1:6379 --file <file.rdb/h5/ms> \
+         --l0-spead 239.102.254.0+1:7148 --l0-interface=lo \
+         --server localhost:2060,localhost:2061

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The simulator uses either an H5 or MS file as the data source.
 
 2. Run the h5 Telescope State simulator:
 
- > sim_ts.py --telstate 127.0.0.1:6379 --file \<file.h5 or file.ms\>
+ > sim_ts.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\>
 
 3. Run the pipeline controller:
 
@@ -28,7 +28,7 @@ The simulator uses either an H5 or MS file as the data source.
 
 4. Run the h5 data stream:
 
- > sim_data_stream.py --telstate 127.0.0.1:6379 --file \<file.h5 or file.ms\>
+ > sim_data_stream.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\>
 
 You can pass `--max-scans` to restrict the number of scans to replay from a large file.
 
@@ -39,7 +39,33 @@ This additionally requires
 * tmux
 * tmuxp (0.8.1+)
 
- > run_katsdpcal_sim.py --telstate 127.0.0.1:6379 --file \<file.h5 or file.ms\> --max-scans=7 --keep-sessions
+ > run_katsdpcal_sim.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\> --max-scans=7 --keep-sessions
 
 The shortcut simulator runs each of the five commands above in separate tmux
 sessions, named redis, sim\_ts, pipeline and sim\_data respectively.
+
+### Multiple pipelines
+
+The multicast groups and the ports for the servers need to be chosen to avoid
+conflicts with anything else that happens to the running on the system; the
+values given are just examples. The instructions below are for two servers, but
+it can scale up to higher numbers.
+
+1. Start a redis server
+
+2. Run the Telescope State simulator:
+
+ > sim_ts.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\> --substreams 2
+
+3. Run the pipeline controller (in parallel):
+
+ > run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
+     --servers 4 -p 2060 --server-id 1
+ > run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
+     --servers 4 -p 2061 --server-id 2
+
+4. Run the h5 data stream:
+
+ > sim_data_stream.py --telstate 127.0.0.1:6379 --file \<file.rdb/h5/ms\> \
+     --l0-spead 239.102.254.0+1:7148 --l0-interface=lo \
+     --server localhost:2060,localhost:2061

--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ it can scale up to higher numbers.
 3. Run the pipeline controller (in parallel):
 
        run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
-         --servers 4 -p 2060 --server-id 1
+         --servers 2 -p 2060 --server-id 1
        run_cal.py --telstate 127.0.0.1:6379 --l0-spead 239.102.254.0+1:7148 --l0-interface lo \
-         --servers 4 -p 2061 --server-id 2
+         --servers 2 -p 2061 --server-id 2
 
 4. Run the h5 data stream:
 

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -15,6 +15,7 @@ import spead2
 from spead2 import send
 from .calprocs import get_reordering_nopol
 
+import katsdpservices
 import katdal
 from katdal.flags import NAMES as FLAG_NAMES
 import katpoint

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -255,7 +255,7 @@ class SimData:
             Index of the substream
         """
         assert array.shape[0] % self.n_substreams == 0
-        n_chans_per_substream = array.shape[1] // self.n_substreams
+        n_chans_per_substream = array.shape[0] // self.n_substreams
         chan0 = n_chans_per_substream * substream
         chan1 = chan0 + n_chans_per_substream
         return array[chan0 : chan1]

--- a/scripts/sim_data_stream.py
+++ b/scripts/sim_data_stream.py
@@ -30,6 +30,9 @@ def parse_opts():
         '--server', type=endpoint.endpoint_list_parser(2048), default='localhost:2048',
         help='Address(es) of cal katcp server(s). Default: %(default)s', metavar='ENDPOINT')
     parser.add_argument(
+        '--l0-interface',
+        help='Interface on which to send L0 spectral data. Default: auto', metavar='INTERFACE')
+    parser.add_argument(
         '--bchan', type=int, default=0, help='First channel to take from file')
     parser.add_argument(
         '--echan', type=int, default=None, help='Last channel to take from file')
@@ -55,7 +58,8 @@ async def main():
         logger.info("Issuing capture-init")
         await simdata.capture_init()
         logger.info("TX: start.")
-        simdata.data_to_spead(telstate, opts.l0_spead, opts.l0_rate, max_scans=opts.max_scans)
+        simdata.data_to_spead(telstate, opts.l0_spead, opts.l0_rate, max_scans=opts.max_scans,
+                              interface=opts.l0_interface)
         logger.info("TX: ended.")
         logger.info("Issuing capture-done")
         await simdata.capture_done()

--- a/scripts/sim_data_stream.py
+++ b/scripts/sim_data_stream.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def parse_opts():
     parser = ArgumentParser(description='Simulate SPEAD data stream from file')
     parser.add_argument(
-        '--l0-spead', type=endpoint.endpoint_parser(7200), default='127.0.0.1:7200',
+        '--l0-spead', type=endpoint.endpoint_list_parser(7200), default='127.0.0.1:7200',
         help='endpoint to send L0 SPEAD stream (including multicast IPs). '
              '[<ip>][:port]. [default=%(default)s]', metavar='ENDPOINT')
     parser.add_argument('--file', type=str, help='File for simulated data (H5 or MS)')
@@ -27,8 +27,8 @@ def parse_opts():
         '--max-scans', type=int, default=None,
         help='Number of scans to transmit. Default: all')
     parser.add_argument(
-        '--server', type=endpoint.endpoint_parser(2048), default='localhost:2048',
-        help='Address of cal katcp server. Default: %(default)s', metavar='ENDPOINT')
+        '--server', type=endpoint.endpoint_list_parser(2048), default='localhost:2048',
+        help='Address(es) of cal katcp server(s). Default: %(default)s', metavar='ENDPOINT')
     parser.add_argument(
         '--bchan', type=int, default=0, help='First channel to take from file')
     parser.add_argument(
@@ -37,14 +37,20 @@ def parse_opts():
     return parser.parse_args()
 
 
+def get_n_substreams(telstate):
+    return telstate['sdp_l0_n_chans'] // telstate['sdp_l0_n_chans_per_substream']
+
+
 async def main():
     setup_logging()
     opts = parse_opts()
 
     logger.info("Use TS set up by sim_ts.py and run_cal.py scripts.")
     telstate = opts.telstate
+    n_substreams = get_n_substreams(telstate)
 
-    simdata = SimData.factory(opts.file, opts.server, bchan=opts.bchan, echan=opts.echan)
+    simdata = SimData.factory(opts.file, opts.server, bchan=opts.bchan, echan=opts.echan,
+                              n_substreams=n_substreams)
     async with simdata:
         logger.info("Issuing capture-init")
         await simdata.capture_init()

--- a/scripts/sim_ts.py
+++ b/scripts/sim_ts.py
@@ -17,6 +17,7 @@ def parse_opts():
     parser.add_argument('--file', type=str, help='H5 or MS file for simulated data')
     parser.add_argument('--bchan', type=int, default=0, help='First channel to take from file')
     parser.add_argument('--echan', type=int, default=None, help='Last channel to take from file')
+    parser.add_argument('--substreams', type=int, default=1, help='Number of substreams (servers)')
     parser.set_defaults(telstate='localhost')
     return parser.parse_args()
 
@@ -27,7 +28,8 @@ async def main():
     telstate = opts.telstate
 
     logging.info("Opening file %s", opts.file)
-    simdata = SimData.factory(opts.file, bchan=opts.bchan, echan=opts.echan)
+    simdata = SimData.factory(opts.file, bchan=opts.bchan, echan=opts.echan,
+                              n_substreams=opts.substreams)
 
     async with simdata:
         logging.info("Clearing telescope state")


### PR DESCRIPTION
Mostly it's a case of accepting multiple arguments for some things, and chopping up the data into the relevant pieces. I also added `--l0-interface` to match the corresponding option to `run_cal.py`, to allow multicast to be routed through the loopback interface instead of spamming the network.