### PR TITLE
Rework store_inplace

### DIFF
--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -260,9 +260,10 @@ def store_inplace(sources, targets, safe=True, **kwargs):
     layers[root_key] = {root_key: out_keys}
     dependencies[root_key] = set(store_layers)
     graph = HighLevelGraph(layers, dependencies)
+    # Ensure that array-appropriate optimizations are performed.
     graph = da.Array.__dask_optimize__(graph, [root_key])
     result = Delayed(root_key, graph)
-    result.compute()
+    result.compute(optimize_graph=False)
 
 
 def _rename(comp, keymap):

--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -91,7 +91,7 @@ def _is_getter(dsk, v):
 
 
 def _safe_inplace(sources, targets):
-    """Safety check on :func:`safe_in_place`. It uses the following algorithm:
+    """Safety check on :func:`store_inplace`. It uses the following algorithm:
 
     1. For each key in the graph, determine a set of :class:`_ArrayDependency`s that
     contribute to it. In most cases this is just all arrays that are reachable

--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -244,6 +244,7 @@ def store_inplace(sources, targets, safe=True, **kwargs):
         out_keys.extend(layer.keys())
         graphs.append(HighLevelGraph.from_collections(name, layer, (source, target)))
     graph = HighLevelGraph.merge(*graphs)
+    graph = da.Array.__dask_optimize__(graph, out_keys)
     dask.base.compute_as_if_collection(da.Array, graph, out_keys)
 
 

--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -78,16 +78,6 @@ def _in_graph(dsk, key):
         return False
 
 
-def _slice_key(slc):
-    """Turn a slice or tuple of slices into a hashable type."""
-    if isinstance(slc, slice):
-        return (slc.start, slc.stop, slc.step)
-    elif isinstance(slc, tuple):
-        return tuple(_slice_key(s) for s in slc)
-    else:
-        raise TypeError(f'Expected slice or tuple of slices, not {type(slc)}')
-
-
 def _is_getter(dsk, v):
     """Check whether an element of a graph is a getter task."""
     # Getters can also have length 5 to pass optional arguments. For

--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -326,6 +326,9 @@ def rename(array, salt=''):
     This is intended to be used when the backing storage has changed
     underneath, to invalidate any caches.
 
+    TODO: once we're able to upgrade to a newer Dask, use
+    :func:`dask.graph_manipulation.clone`.
+
     Parameters
     ----------
     array : :class:`dask.array.Array`

--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -19,7 +19,7 @@ from dask.highlevelgraph import HighLevelGraph
 try:
     from dask.highlevelgraph import MaterializedLayer
 except ImportError:
-    # Older verisons of dask don't have this. We only use it for an instance
+    # Older versions of dask don't have this. We only use it for an instance
     # check, so a dummy implementation suffices.
     class MaterializedLayer:
         pass

--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -138,7 +138,6 @@ class _StoreWrapper:
                 raise ValueError(f'Target key {key} does not directly map a numpy array')
             # Slices are not hashable
             self._slice_map[_slice_key(slc)] = ndarray
-        print(self._slice_map.keys())
 
     def __setitem__(self, idx, value):
         self._slice_map[_slice_key(idx)][:] = value

--- a/katsdpcal/inplace.py
+++ b/katsdpcal/inplace.py
@@ -102,12 +102,10 @@ def _array_get(dsk, key, cache):
     v = dsk[key]
     if _is_getter(dsk, v):
         array = v[0](_array_get(dsk, v[1], cache), v[2])
+    elif _in_graph(dsk, v):
+        array = _array_get(dsk, v, cache)
     else:
-        try:
-            array = dsk[v]
-        except (KeyError, TypeError):
-            # Either missing or not hashable
-            array = v
+        array = v
 
     if not isinstance(array, np.ndarray):
         raise ValueError(f'Key {key} does not refer to an array')

--- a/katsdpcal/test/test_inplace.py
+++ b/katsdpcal/test/test_inplace.py
@@ -3,18 +3,27 @@
 from nose.tools import assert_raises, assert_false
 import numpy as np
 import dask.array as da
+import dask.distributed
 
 from katsdpcal import inplace
 
 
 class TestStoreInplace:
     def setup(self):
+        self.cluster = dask.distributed.LocalCluster(
+            n_workers=1, threads_per_worker=4,
+            processes=False, memory_limit=0)
+        self.client = dask.distributed.Client(self.cluster)
         # Variables with n prefix are numpy arrays
         self.na = np.arange(36).reshape(6, 6)
         self.nx = np.arange(24).reshape(6, 4)
         self.a = da.from_array(self.na, chunks=(3, 2), name=False)
         self.b = da.ones(6, chunks=(2,))
         self.x = da.from_array(self.nx, chunks=(3, 2), name=False)
+
+    def teardown(self):
+        self.client.close()
+        self.cluster.close()
 
     def test_simple(self):
         orig = self.na.copy()


### PR DESCRIPTION
A lot of the code in `store_inplace` pre-dates HighLevelGraph in Dask, and tended to materialize low-level graphs earlier than necessary and thus potentially disable high-level optimisations. It's rewritten using high-level layers, so that other than the safety check and the actual computation, performance should only depend on the number of layers involved rather than the number of chunks.

It also fixes some of the `rename` code to work with newer Dask versions that have extra fields in Blockwise layers.