### PR TITLE
Generate report even when no refant is selected

### DIFF
--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -1593,13 +1593,6 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
             cal_rst.writeln('Stream: {}'.format(stream_name))
             cal_rst.writeln()
 
-            # Obtain reference antenna selected by the pipeline
-            refant_name = ts.get('refant')
-            if refant_name is not None:
-                refant_index = parameters['antenna_names'].index(refant_name)
-                parameters['refant'] = refant_name
-                parameters['refant_index'] = refant_index
-
             antennas = parameters['antennas']
             if av_corr:
                 targets, times = zip(*av_corr['targets'])
@@ -1616,17 +1609,24 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
             pol = [_[0].upper() for _ in parameters['pol_ordering']]
             antenna_names = list(parameters['antenna_names'])
 
+            # Obtain reference antenna selected by the pipeline
+            refant_name = ts.get('refant')
+            if refant_name is not None:
+                refant_index = parameters['antenna_names'].index(refant_name)
+                parameters['refant'] = refant_name
+                parameters['refant_index'] = refant_index
+
+                # label the reference antenna in the list of antennas
+                refant_name = antenna_names[refant_index]
+                antenna_names[refant_index] += ', refant'
+                name_width = len(antenna_names[refant_index])
+                antenna_names = [name.ljust(name_width) for name in antenna_names]
+
+            else:
+                logger.info(' - no reference antenna')
+                refant_index = None
+
             if av_corr:
-                # label the reference antenna in the list of antennas, if it has been selected
-                if refant_index is not None:
-                    refant_name = antenna_names[refant_index]
-                    antenna_names[refant_index] += ', refant'
-                    name_width = len(antenna_names[refant_index])
-                    antenna_names = [name.ljust(name_width) for name in antenna_names]
-
-                else:
-                    logger.info(' - no reference antenna selected')
-
                 write_elevation(cal_rst, report_path, unique_targets,
                                 antennas, refant_index, av_corr)
                 # -------------------------------------------------------------------

--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -1612,12 +1612,11 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
             # Obtain reference antenna selected by the pipeline
             refant_name = ts.get('refant')
             if refant_name is not None:
-                refant_index = parameters['antenna_names'].index(refant_name)
+                refant_index = antenna_names.index(refant_name)
                 parameters['refant'] = refant_name
                 parameters['refant_index'] = refant_index
 
                 # label the reference antenna in the list of antennas
-                refant_name = antenna_names[refant_index]
                 antenna_names[refant_index] += ', refant'
                 name_width = len(antenna_names[refant_index])
                 antenna_names = [name.ljust(name_width) for name in antenna_names]


### PR DESCRIPTION
This is to address SPR1-1117, certain observations (mainly TRAPUM
targets) do not observe any calibrators, only targets. The pipeline is
only triggered to select a reference antenna when a calibrator target is
observerd so for these observations no reference antenna is selected.

This PR fixes a problem with internal logic of generating a report when
no reference antenna is selected.