### PR TITLE
Handle case when calibrators are tagged as targets

### DIFF
--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -829,13 +829,15 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
 
             # summarize gain-calibrated targets
             gaintag = ['gaincal', 'target', 'bfcal']
+            nogaintag = ['bpcal', 'delaycal']
             if any(k in gaintag for k in taglist):
                 s.summarize_full(av_corr, target_name + '_g_spec', nchans=1024)
                 s.summarize(av_corr, target_name + '_g_bls')
-                if not any('target' in k for k in taglist):
+                gaincaltag = ['gaincal', 'bfcal']
+                if any(k in gaincaltag for k in taglist):
                     s.summarize(av_corr, target_name + '_g_phase', avg_ant=True)
             # summarize non-gain calibrated targets
-            else:
+            if any(k in nogaintag for k in taglist):
                 s.summarize(av_corr, target_name + '_nog_spec', nchans=1024, refant_only=True)
 
     return target_slices, av_corr

--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -1410,15 +1410,19 @@ def split_targets(targets):
         kat_target = katpoint.Target(cal)
         tags = kat_target.tags
         # tags which have gains applied by pipeline
-        gaintaglist = ('gaincal', 'bfcal', 'target')
-        if not any(x in gaintaglist for x in tags):
+        gaintaglist = ('gaincal', 'bfcal')
+        nogaintaglist = ('bpcal', 'delaycal')
+        if any(x in nogaintaglist for x in tags):
             nogain.append(cal)
-        elif 'target' in tags:
-            target.append(cal)
-        else:
+        if any(x in gaintaglist for x in tags):
             gain.append(cal)
         if 'polcal' in tags:
             pol.append(cal)
+        # if a target is a calibrator, don't include it here as it will already be included
+        # in the calibrator plots
+        if ('target' in tags and
+                not any(x in nogaintaglist + gaintaglist for x in tags)):
+            target.append(cal)
     return nogain, gain, pol, target
 
 


### PR DESCRIPTION
SPR1-1301, some users add a `target` tag to their calibrators, this
caused the calibration report to only generate `target` style plots
in the report. This PR modifies the report to only generate the
`calibrator` style plots in these cases, which usually contain both
phase and amplitude information (instead of just amplitude for
`targets`) for better insight into the calibration success on these
calibrators.