### PR TITLE
Hetero beams

### DIFF
--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -524,7 +524,11 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                  chans=parameters['channel_freqs'],
                  ants=parameters['antennas'],
                  refant=refant_ind,
-                 array_position=parameters['array_position'], logger=logger)
+                 array_position=parameters['array_position'],
+                 pol_order=parameters['pol_ordering'],
+                 mkat_beam_model=parameters['mkat_beam_model'],
+                 ska_beam_model=parameters['ska_beam_model'],
+                 logger=logger)
         if s.xc_mask.size == 0:
             logger.info('No XC data - no processing performed.')
             continue

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -760,7 +760,9 @@ class SimDataKatdal(SimData):
         f_engine_stream = telstate.view(correlator_stream)['src_streams'][0]
 
         band_mask_key = telstate.join(f_engine_stream, 'model', 'band_mask', 'fixed')
-        model_keys = [band_mask_key, 'sdp_model_base_url',
+        primary_beam_key = telstate.join(f_engine_stream, 'model', 'primary_beam',
+                                         'cohort', 'fixed')
+        model_keys = [band_mask_key, primary_beam_key, 'sdp_model_base_url',
                       'model_rfi_mask_fixed', 'sdp_l0_src_streams',
                       telstate.join(correlator_stream, 'src_streams')]
         for key in model_keys:

--- a/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/test/test_calprocs.py
@@ -550,14 +550,19 @@ class TestAddModelVis(unittest.TestCase):
         ant1 = np.array([0, 0, 0, 1, 1, 2])
         ant2 = np.array([1, 2, 3, 2, 3, 3])
 
+        beam = np.ones((3, 5, 2), np.complex64)
+        beam[1, 3, 1] = 0.5j
+        beam_ant1 = np.array([0, 0, 0, 0, 0, 0])
+        beam_ant2 = np.array([0, 0, 1, 0, 1, 1])
+
         out_shape = (3, 5, 6)
         model = np.ones(out_shape, np.complex64)
         S = np.array([5, 4, 3, 2, 1])
 
-        out_model = calprocs.add_model_vis(kant, ant1, ant2, S, model)
+        out_model = calprocs.add_model_vis(kant, ant1, ant2, S, beam, beam_ant1, beam_ant2, model)
 
         expected_model = np.ones(out_shape, np.complex64) + S[np.newaxis, :, np.newaxis]
-        expected_model[1, 3, :] = [5, 3-2j, 5-4j, 5-4j, 9-8j, 9]
+        expected_model[1, 3, :] = [5, 3-2j, -1-2j, 5-4j, -3-4j, 1-4j]
 
         np.testing.assert_equal(out_model, expected_model)
 

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -218,6 +218,15 @@ class TestCalDeviceServer(asynctest.TestCase):
         self.addCleanup(patcher.stop)
         return mock_obj
 
+    def populate_telstate_beam(self, telstate, correlator_stream):
+        f_engine_stream = 'antenna_channelised_voltage'
+        beam_url = 'primary_beam/config/cohort/meerkat/l/v1.alias'
+        telstate_corr = telstate.view(correlator_stream)
+        telstate_corr['src_streams'] = [f_engine_stream]
+        primary_beam_key = telstate.join(f_engine_stream, 'model',
+                                         'primary_beam', 'cohort', 'fixed')
+        telstate[primary_beam_key] = {ant: beam_url for ant in self.antennas}
+
     def populate_telstate_cb(self, telstate, cb='cb'):
         telstate_cb_l0 = telstate.view(telstate.join(cb, 'sdp_l0test'))
         telstate_cb_l0['first_timestamp'] = 100.0
@@ -262,6 +271,10 @@ class TestCalDeviceServer(asynctest.TestCase):
         telstate_l0['sync_time'] = 1400000000.0
         telstate_l0['excise'] = True
         telstate_l0['need_weights_power_scale'] = True
+        telstate_l0['sdp_model_base_url'] = 'https://sdpmodels.kat.ac.za/'
+        correlator_stream = 'baseline_correlation_products'
+        telstate_l0['src_streams'] = [correlator_stream]
+        self.populate_telstate_beam(telstate, correlator_stream)
         self.populate_telstate_cb(telstate)
         for antenna in self.antennas:
             # The position is irrelevant for now, so just give all the

--- a/katsdpcal/test/test_pipelineprocs.py
+++ b/katsdpcal/test/test_pipelineprocs.py
@@ -193,11 +193,24 @@ class TestFinaliseParameters(unittest.TestCase):
 
         self.telstate = katsdptelstate.TelescopeState()
         self.telstate.clear()
+        # add primary beam keys to telstate
+        correlator_stream = 'baseline_correlation_products'
+        f_engine_stream = 'antenna_channelised_voltage'
+        beam_url = 'primary_beam/config/cohort/meerkat/l/v1.alias'
+        self.telstate_corr = self.telstate.view(correlator_stream)
+        self.telstate_corr['src_streams'] = [f_engine_stream]
+        primary_beam_key = self.telstate.join(f_engine_stream, 'model',
+                                              'primary_beam', 'cohort', 'fixed')
+        self.telstate[primary_beam_key] = {'m001': beam_url}
         self.telstate_l0 = self.telstate.view('sdp_l0test')
+        self.telstate_l0['sdp_model_base_url'] = 'https://sdpmodels.kat.ac.za/'
+
+        self.telstate_l0['src_streams'] = [correlator_stream]
         self.telstate_l0['n_chans'] = 4096
         self.telstate_l0['bandwidth'] = 856000000.0
         self.telstate_l0['center_freq'] = 1284000000.0
         self.telstate_l0['bls_ordering'] = bls_ordering
+
         for antenna in self.antennas:
             self.telstate[self.telstate.join(antenna.name, 'observer')] = antenna.description
         self.expected_freqs_all = np.arange(4096) / 4096 * 856000000.0 + 856000000.0


### PR DESCRIPTION
Enable the pipeline to use primary beam models when predicting model visibilities. This will allow it to use an intrinsic sky model for calibrator fields, which can then be modified by the appropriate primary beam model to produce different apparent sky models for MeerKAT and SKA dishes.  

This cannot be properly tested or merged until we have an appropriate intrinsic sky model for the calibrator fields. The currently used models are all apparent sky models (for MeerKAT antennas) 