### PR TITLE
SPR1-1869: Pre_g solutions are relative to the mean

### DIFF
--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -341,7 +341,7 @@ class Scan:
         use_model : bool, optional
             if True correct visibilities by available model
         relative : bool, optional
-            if True adjust the solution to be relative to the first solution in the time series
+            if True adjust the solution to be relative to the mean solution in the time series
 
         Returns
         -------
@@ -400,7 +400,7 @@ class Scan:
         else:
             snr = None
 
-        fin_g_soln = g_soln / g_soln[0] if relative else g_soln
+        fin_g_soln = g_soln / np.nanmean(g_soln, axis=0) if relative else g_soln
         cal_soln = CalSolutions('G', fin_g_soln, ave_times, soltarget=self.target.name, solsnr=snr)
         return cal_soln
 


### PR DESCRIPTION
Previously pre_g gain solutions were altered to be relative to the first
solution per antenna. This was intended to make the solutions more
robust to poor antennas, while still allowing the pre_g gain solution to
remove any gain drift across the calibrator scan.

Unfortunately this makes the solutions very sensitive to the quality of
the first dump in the scan. If this dump is flagged (as can easily
happen if an antenna is straggling) then all solutions relative to this
flagged (NaN'ed) solution will become NaN. To prevent this the solutions
are now relative to the mean solution for scan interval.