### PR TITLE
Interpolate across NaN gain solutions

### DIFF
--- a/katsdpcal/calprocs.py
+++ b/katsdpcal/calprocs.py
@@ -683,31 +683,39 @@ def add_model_vis(k_ant, ant1, ant2, I, model):    # noqa: E741
     return model
 
 
-def interpolate_bandpass(x):
-    """Interpolate over NaNs in the channel axis of a bandpass.
+def interpolate_soln(x, xi, yi):
+    """Interpolate over NaNs in the first axis of a cal solution.
 
     Parameters
     ----------
-    x : :class:`np.ndarray`, complex, shape(nchans, npols, nants)
-        bandpass to interpolate over
+    x : 1-D sequence of float, length *M*
+        The x-coordinates at which to evaluate the interpolated values
+    xi : 1-D sequence of float, length *N*
+        The x-coordinates of the data points, must be sorted in ascending order
+    yi : :class:`np.ndarray`, complex, shape(N, npols, nants)
+        solution to interpolate over, first axis must match the length of xi
 
     Returns
     -------
-    x_interp : :class`np.ndarray`
-         interpolated bandpass
+    y_interp : :class`np.ndarray`
+         interpolated solution, shape(M, npols, nants)
     """
-    nchans, npols, nants = x.shape
-    x_interp = np.empty_like(x)
+    x = np.array(x)
+    xi = np.array(xi)
+
+    n, npols, nants = yi.shape
+    ni = len(x)
+    y_interp = np.zeros((ni, npols, nants), dtype=yi.dtype)
     for p in range(npols):
         for a in range(nants):
-            valid = np.isfinite(x[:, p, a])
+            valid = np.isfinite(yi[:, p, a])
             if np.any(valid):
-                x_interp[:, p, a] = complex_interp(np.arange(nchans),
-                                                   np.arange(nchans)[valid],
-                                                   x[:, p, a][valid])
+                y_interp[:, p, a] = complex_interp(x,
+                                                   xi[valid],
+                                                   yi[:, p, a][valid])
             else:
-                x_interp[:, p, a] = np.nan
-    return x_interp
+                y_interp[:, p, a] = np.nan
+    return y_interp
 
 
 def asbool(arr):

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -18,7 +18,7 @@ from . import solutions
 from . import pipelineprocs as pp
 from .scan import Scan
 from . import lsm_dir
-from .calprocs import interpolate_bandpass
+from .calprocs import interpolate_soln
 
 logger = logging.getLogger(__name__)
 
@@ -379,7 +379,8 @@ def shared_B_interp_nans(telstate, parameters, b_soln, st, et):
         b_values = b_soln.values
 
     # interpolate over NaNs along the channel axis
-    b_interp = interpolate_bandpass(b_values)
+    nchans, npols, nants = b_values.shape
+    b_interp = interpolate_soln(np.arange(nchans), np.arange(nchans), b_values)
 
     # select channels processed by this cal node
     b_interp = b_interp[parameters['channel_slice']]

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -379,7 +379,7 @@ def shared_B_interp_nans(telstate, parameters, b_soln, st, et):
         b_values = b_soln.values
 
     # interpolate over NaNs along the channel axis
-    nchans, npols, nants = b_values.shape
+    nchans, *_ = b_values.shape
     b_interp = interpolate_soln(np.arange(nchans), np.arange(nchans), b_values)
 
     # select channels processed by this cal node

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -988,13 +988,7 @@ class Scan:
             # case of only one solution value being interpolated
             return CalSolutions(solns.soltype, solns.values, self.timestamps)
         else:
-            real_interp = scipy.interpolate.interp1d(
-                timestamps, values.real, kind='linear', axis=0, fill_value='extrapolate')
-            imag_interp = scipy.interpolate.interp1d(
-                timestamps, values.imag, kind='linear', axis=0, fill_value='extrapolate')
-            # interp1d gives float64 answers even given float32 inputs
-            interp_solns = real_interp(self.timestamps).astype(np.float32) \
-                + 1.0j * imag_interp(self.timestamps).astype(np.float32)
+            interp_solns = calprocs.interpolate_soln(self.timestamps, timestamps, values)
             return CalSolutions(solns.soltype, interp_solns, self.timestamps)
 
     def inf_interpolate(self, soln):

--- a/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/test/test_calprocs.py
@@ -786,3 +786,29 @@ class TestGetReordering(unittest.TestCase):
         self.assertEqual(bls_wanted, [['m000', 'm001'], ['m000', 'm002'], ['m001', 'm002']])
         self.assertEqual(pol_order, [['v', 'v'], ['h', 'h'], ['v', 'h'], ['h', 'v']])
         np.testing.assert_array_equal(ordering, [3, 7, 11, 2, 6, 10, 1, 5, 9, 0, 4, 8])
+
+
+class TestInterpolateSoln(unittest.TestCase):
+    """Tests for :func:`katsdpcal.calprocs.interpolate_soln`"""
+    def test(self):
+        shape = (4, 2, 5)
+        xi = [1, 2, 4, 5]
+
+        soln = np.ones(shape, np.complex64)
+        soln_mag = np.array([2, 4, 8, 10])
+        soln_angle = np.pi / 180 * np.array([10, 20, 40, 50])
+        soln_complex = soln_mag * np.exp(1.j * soln_angle)
+
+        # Test interpolation with and without NaN's
+        soln[:, 0, 2] = soln_complex
+        soln_complex[[1, 3]] = np.nan
+        soln[:, 1, 2] = soln_complex
+ 
+        x = [3, 6]
+        out = calprocs.interpolate_soln(x, xi, soln)
+
+        expected = np.ones((2, 2, 5), np.complex64)
+        expected[:, 0, 2] = np.array([6, 10]) * np.exp(1.j * np.pi / 180 * np.array([30, 50]))
+        expected[:, 1, 2] = np.array([6, 8]) * np.exp(1.j * np.pi / 180 * np.array([30, 40]))
+
+        np.testing.assert_almost_equal(out, expected, 6)

--- a/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/test/test_calprocs.py
@@ -803,7 +803,7 @@ class TestInterpolateSoln(unittest.TestCase):
         soln[:, 0, 2] = soln_complex
         soln_complex[[1, 3]] = np.nan
         soln[:, 1, 2] = soln_complex
- 
+
         x = [3, 6]
         out = calprocs.interpolate_soln(x, xi, soln)
 


### PR DESCRIPTION
As seen in [SOQ-3](https://skaafrica.atlassian.net/browse/SOQ-3) if a gain solution is a NaN for any reason, when this
solution is interpolated and applied to a target scan it will cause that
scan to be completely flagged by the cal pipeline. This PR allows the
pipeline to ignore these NaN gain solutions and interpolate from the
nearest valid gain solution.