### PR TITLE
SPR1-2871: Fixing numpy deprecated aliases such as np.float

### DIFF
--- a/katsdpcal/calprocs.py
+++ b/katsdpcal/calprocs.py
@@ -761,7 +761,7 @@ def solint_from_nominal(solint, dump_period, num_times):
         dumps_per_solint_low = int(np.round(req_dumps_per_solint * 0.8))
         dumps_per_solint_high = int(np.round(req_dumps_per_solint * 1.2))
         solint_check_range = np.arange(dumps_per_solint_low,
-                                       dumps_per_solint_high + 1).astype(np.int)
+                                       dumps_per_solint_high + 1).astype(int)
 
         # compute size of final partial interval (in dumps)
         tail = (num_times - 1) % solint_check_range + 1
@@ -1077,7 +1077,7 @@ def fake_vis(shape=(7,), gains=None, noise=None, random_state=None):
     list1 = np.hstack([list1, antlist])
     list1 = np.int_(list1)
 
-    list2 = np.array([], dtype=np.int)
+    list2 = np.array([], dtype=int)
     mod_antlist = antlist[1:]
     for i in range(0, len(mod_antlist)):
         list2 = np.hstack([list2, mod_antlist[:]])
@@ -1150,7 +1150,7 @@ def wavg_full_f(data, flags, weights, chanav, threshold=0.8):
         real (..., av_chans, npols, nbls), weighted average of weights
     """
     # ensure chanav is an integer
-    chanav = np.int(chanav)
+    chanav = int(chanav)
     inc_array = list(range(0, data.shape[-3], chanav))
 
     # suppress any comparison-with-nan errors by replacing them with zeros

--- a/katsdpcal/calprocs_dask.py
+++ b/katsdpcal/calprocs_dask.py
@@ -195,8 +195,8 @@ def wavg_full_t(data, flags, weights, solint, times=None, threshold=0.8):
     av_weights : weighted average of weights
     av_times   : optional average of times
     """
-    # ensure solint is an intager
-    solint = np.int(solint)
+    # ensure solint is an integer
+    solint = int(solint)
     inc_array = range(0, data.shape[0], solint)
 
     av_data = []

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1144,7 +1144,7 @@ class Pipeline(Task):
         Note: do not call this `_run`, since that is a method of the base class.
         """
         # Ensure that parallelism in numba is thread & fork safe
-        numba.config.THREADING_LAYER = 'threadsafe'
+        numba.config.THREADING_LAYER = 'safe'
         # Ensure that numba doesn't starve the accumulator. The number of
         # threads cannot be set higher than NUMBA_NUM_THREADS (which needs to
         # be overridden from the environment).

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1144,7 +1144,7 @@ class Pipeline(Task):
         Note: do not call this `_run`, since that is a method of the base class.
         """
         # Ensure that parallelism in numba is thread & fork safe
-        numba.config.THREADING_LAYER = 'safe'
+        numba.config.THREADING_LAYER = 'threadsafe'
         # Ensure that numba doesn't starve the accumulator. The number of
         # threads cannot be set higher than NUMBA_NUM_THREADS (which needs to
         # be overridden from the environment).
@@ -1791,7 +1791,7 @@ def create_buffer_arrays(buffer_shape, use_multiprocessing=True):
     data['flags'] = factory(buffer_shape, dtype=np.uint8)
     data['excise'] = factory(excise_shape, dtype=np.uint8)
     data['weights'] = factory(buffer_shape, dtype=np.float32)
-    data['times'] = factory(buffer_shape[0], dtype=np.float)
+    data['times'] = factory(buffer_shape[0], dtype=float)
     data['dump_indices'] = factory(buffer_shape[0], dtype=np.uint64)
     return data
 

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -194,7 +194,7 @@ def parameters_from_file(filename):
     The file has the format :samp:`{key}: {value}`. Hashes (#) introduce
     comments.
     """
-    rows = np.loadtxt(filename, delimiter=':', dtype=np.str, comments='#')
+    rows = np.loadtxt(filename, delimiter=':', dtype=str, comments='#')
     raw_params = {key.strip(): value.strip() for (key, value) in rows}
     param_dict = {}
     for parameter in USER_PARAMS_FREQS + USER_PARAMS_CHANS:

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -41,7 +41,7 @@ def init_flagger(parameters, dump_period):
         A SumThresholdFlagger object for use with targets
     """
     # Make windows a integer array
-    rfi_windows_freq = np.array(parameters['rfi_windows_freq'], dtype=np.int)
+    rfi_windows_freq = np.array(parameters['rfi_windows_freq'], dtype=int)
     spike_width_time = parameters['rfi_spike_width_time'] / dump_period
     calib_flagger = SumThresholdFlagger(outlier_nsigma=parameters['rfi_calib_nsigma'],
                                         windows_freq=rfi_windows_freq,

--- a/scripts/run_cal.py
+++ b/scripts/run_cal.py
@@ -337,7 +337,7 @@ def main():
     scale_factor = 8. + 1. + 4. + 0.125  # vis + flags + weights + excision
     time_factor = 8. + 0.1  # time + 0.1 for good measure (indiced)
     array_length = opts.buffer_maxsize/((scale_factor*n_chans*npols*nbl) + time_factor)
-    array_length = np.int(np.ceil(array_length))
+    array_length = int(np.ceil(array_length))
     logger.info('Buffer size : %f GB', opts.buffer_maxsize / 1e9)
     logger.info('Total slots in buffer : %d', array_length)
 


### PR DESCRIPTION
`np.float`, `np.int` and `np.str` are deprecated as of NumPy 1.20. Use the built-in standard such as `float` instead.