### PR TITLE
Incorporate base-requirements as defaults rather than constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
--c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
+-d https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
 aiokatcp
 astropy


### PR DESCRIPTION
Previously, base-requirements from docker-base-build were incorporated (by install_pinned.py) as constraints rather than defaults. Here, we change that behaviour, because several dependencies of katsdpcal have been held back (see https://skaafrica.atlassian.net/browse/SPR1-1790)