### PR TITLE
SPR1-2993: New PipelineSyncEvent triggered by "await_pipeline" scan

### DIFF
--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -261,6 +261,14 @@ def make_telstate_cb(telstate, capture_block_id):
     return telstate.view(capture_block_id).view(prefix)
 
 
+def _run_task(task):
+    """Free function wrapping the Task runner.
+
+    It needs to be free because bound instancemethods can't be pickled for multiprocessing.
+    """
+    task._run()
+
+
 class Task:
     """Base class for tasks (threads or processes).
 
@@ -331,14 +339,6 @@ class Task:
     @daemon.setter
     def daemon(self, value):
         self._process.daemon = value
-
-
-def _run_task(task):
-    """Free function wrapping the Task runner.
-
-    It needs to be free because bound instancemethods can't be pickled for multiprocessing.
-    """
-    task._run()
 
 
 class Accumulator:
@@ -490,6 +490,25 @@ class Accumulator:
 
             return False
 
+        def _flush_slots(self):
+            now = time.time()
+            self._logger.info('Accumulated %d timestamps', len(self._slots))
+            _inc_sensor(self.owner.sensors['accumulator-batches'], 1, timestamp=now)
+
+            # pass the buffer to the pipeline
+            if self._slots:
+                self.owner.accum_pipeline_queue.put(
+                    BufferReadyEvent(self.capture_block_id, self._slots))
+                self._logger.info('accum_pipeline_queue updated by %s', self.owner.name)
+                _inc_sensor(self.owner.sensors['pipeline-slots'],
+                            len(self._slots), timestamp=now)
+                _inc_sensor(self.owner.sensors['accumulator-slots'],
+                            -len(self._slots), timestamp=now)
+
+            self._slots = []
+            self._slot_for_index.clear()
+            self._state = None
+
         async def _ensure_slots(self, cur_idx, stop_pred=lambda: False):
             """Add new slots until there is one for `cur_idx`.
 
@@ -537,25 +556,6 @@ class Accumulator:
                 self._state = new_state
                 self._last_idx = idx
             return True
-
-        def _flush_slots(self):
-            now = time.time()
-            self._logger.info('Accumulated %d timestamps', len(self._slots))
-            _inc_sensor(self.owner.sensors['accumulator-batches'], 1, timestamp=now)
-
-            # pass the buffer to the pipeline
-            if self._slots:
-                self.owner.accum_pipeline_queue.put(
-                    BufferReadyEvent(self.capture_block_id, self._slots))
-                self._logger.info('accum_pipeline_queue updated by %s', self.owner.name)
-                _inc_sensor(self.owner.sensors['pipeline-slots'],
-                            len(self._slots), timestamp=now)
-                _inc_sensor(self.owner.sensors['accumulator-slots'],
-                            -len(self._slots), timestamp=now)
-
-            self._slots = []
-            self._slot_for_index.clear()
-            self._state = None
 
         @classmethod
         def _update_buffer(cls, out, l0, ordering):
@@ -902,6 +902,14 @@ class Accumulator:
     def capturing(self):
         return self.sensors['accumulator-capture-active'].value
 
+    def set_ordering_parameters(self):
+        # determine re-ordering necessary to convert from supplied bls
+        # ordering to desired bls ordering
+        antenna_names = self.parameters['antenna_names']
+        bls_ordering = self.telstate_l0['bls_ordering']
+        self.ordering = calprocs.get_reordering(antenna_names, bls_ordering)[0]
+        self.weight_power_scale_params = corrprod_to_autocorr(bls_ordering)
+
     async def _next_slot(self, stop_pred=lambda: False):
         """Obtain a new slot in which to store data.
 
@@ -1041,14 +1049,6 @@ class Accumulator:
             self._thread_pool.stop()
             self._thread_pool = None
 
-    def set_ordering_parameters(self):
-        # determine re-ordering necessary to convert from supplied bls
-        # ordering to desired bls ordering
-        antenna_names = self.parameters['antenna_names']
-        bls_ordering = self.telstate_l0['bls_ordering']
-        self.ordering = calprocs.get_reordering(antenna_names, bls_ordering)[0]
-        self.weight_power_scale_params = corrprod_to_autocorr(bls_ordering)
-
 
 class Pipeline(Task):
     """Task (Process or Thread) which runs pipeline."""
@@ -1121,6 +1121,29 @@ class Pipeline(Task):
                 float, 'pipeline-final-flag-fraction-cross-pol',
                 'Final flag fraction post RFI detection: cross-pol (prometheus: Gauge)')
         ]
+
+    def run_pipeline(self, capture_block_id, data):
+        # run pipeline calibration
+        telstate_cb_cal = make_telstate_cb(self.telstate_cal, capture_block_id)
+        target_slices, avg_corr = pipeline(data, telstate_cb_cal, self.parameters,
+                                           self.solution_stores, self.l0_name, self.sensors)
+        # put corrected data into pipeline_report_queue
+        self.pipeline_report_queue.put(avg_corr)
+
+    def get_measured_flux(self, event):
+        # Get the flux densities of the gain calibrators
+        measured_flux, measured_flux_std = calprocs.measure_flux(
+            self.solution_stores['G_FLUX'], self.solution_stores['G'],
+            event.start_time, event.end_time)
+        # Save it to telstate
+        ts_cb_cal = make_telstate_cb(self.telstate_cal, event.capture_block_id)
+        # Only save the key if another process hasn't done it already
+        try:
+            ts_cb_cal.add('measured_flux', measured_flux, immutable=True)
+            ts_cb_cal.add('measured_flux_std', measured_flux_std, immutable=True)
+            logger.info('Saved flux densities of gain calibrators to telstate.')
+        except ImmutableKeyError:
+            pass
 
     def run(self):
         """Task (Process or Thread) run method, which runs pipeline.
@@ -1208,29 +1231,6 @@ class Pipeline(Task):
         finally:
             self.pipeline_sender_queue.put(StopEvent())
             self.pipeline_report_queue.put(StopEvent())
-
-    def run_pipeline(self, capture_block_id, data):
-        # run pipeline calibration
-        telstate_cb_cal = make_telstate_cb(self.telstate_cal, capture_block_id)
-        target_slices, avg_corr = pipeline(data, telstate_cb_cal, self.parameters,
-                                           self.solution_stores, self.l0_name, self.sensors)
-        # put corrected data into pipeline_report_queue
-        self.pipeline_report_queue.put(avg_corr)
-
-    def get_measured_flux(self, event):
-        # Get the flux densities of the gain calibrators
-        measured_flux, measured_flux_std = calprocs.measure_flux(
-            self.solution_stores['G_FLUX'], self.solution_stores['G'],
-            event.start_time, event.end_time)
-        # Save it to telstate
-        ts_cb_cal = make_telstate_cb(self.telstate_cal, event.capture_block_id)
-        # Only save the key if another process hasn't done it already
-        try:
-            ts_cb_cal.add('measured_flux', measured_flux, immutable=True)
-            ts_cb_cal.add('measured_flux_std', measured_flux_std, immutable=True)
-            logger.info('Saved flux densities of gain calibrators to telstate.')
-        except ImmutableKeyError:
-            pass
 
 
 @attr.s

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -844,3 +844,19 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 s.summarize(av_corr, target_name + '_nog_spec', nchans=1024, refant_only=True)
 
     return target_slices, av_corr
+
+
+def flush_pipeline(ts, parameters, solution_stores):
+    """Flush pending calibration products in pipeline.
+
+    Parameters
+    ----------
+    ts : :class:`katsdptelstate.TelescopeState`
+        Telescope state, scoped to the cal namespace within the capture block
+    parameters : dict
+        The pipeline parameters
+    solution_stores : dict of :class:`~.CalSolutionStore`-like
+        Solution stores for the capture block, indexed by solution type
+    """
+    logger.info('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+    logger.info('Flushed pipeline')


### PR DESCRIPTION
Introduce a new scan activity state called "await_pipeline". This serves two main purposes:

- It allows the telescope to continue tracking the calibrator while signalling the end of the solution interval. Previously we slammed on the brakes on the antennas to go to "stop" just to trigger the pipeline in calibrate_delays / bf_phaseup, which is clearly a kludge. It also makes the data during this "stop" scan less valuable. The new scheme ensures extra valid data in the archive.

- It provides an opportunity to flush any pending calibration products from the pipeline. This is important for reference pointing, which needs to do the beam fitting after all the offset data has been processed. This is actually the main driver for this functionality.

When the observation script sets the "await_pipeline" activity, it triggers a break in the Accumulator task and additionally sends a `PipelineSyncEvent` to the Pipeline task. The Pipeline task processes this event by running a `flush_pipeline` function which currently does nothing, but will do reference pointing beam fitting in future.

The data captured during the "await_pipeline" scan is ignored by the pipeline, since this activity is in the `ignore_states` list in the `_is_break` method. The cal pipeline therefore treats this scan as a slew, while katdal will eventually expose this as a track for the benefit of other users.

In the process I also shuffled code around to more logical places and consolidated and reworked `test_control` to reduce redundancy, so it's probably worth reviewing this commit by commit. The bulk of the PR is actually just moving stuff around and the main action happens in commits 177ffaa and c54e8eb, which only adds about 60 lines of code.