### PR TITLE
SPR1-1964: Reference Antenna Selection

### DIFF
--- a/katsdpcal/calprocs.py
+++ b/katsdpcal/calprocs.py
@@ -331,7 +331,7 @@ def ants_from_bllist(bllist):
 
 def select_med_deviation_pnr_ants(med_pnr_ants):
     """Median Absolute Deviation of Reference Antenna PNR values.
-    Select antenna peak to noise (PNR) values that are above one median deviation of the
+    Select antenna peak to noise (PNR) values that are below one normalised median deviation of the
     antenna median PNR for best reference antenna selection. This ensures
     that a subset of antennas with reasonable peak to noise are selected.
 
@@ -344,7 +344,7 @@ def select_med_deviation_pnr_ants(med_pnr_ants):
     -------
     select_med_deviation_pnr_ants : class:`np.ndarray`
        Array of corresponding ant indices with PNR values that are above the normalised
-       median absolute deviation threshold """
+       median absolute deviation threshold"""
 
     ant_indices = np.arange(len(med_pnr_ants))
     median = np.nanmedian(med_pnr_ants)

--- a/katsdpcal/calprocs.py
+++ b/katsdpcal/calprocs.py
@@ -331,9 +331,9 @@ def ants_from_bllist(bllist):
 
 def select_med_deviation_pnr_ants(med_pnr_ants):
     """Median Absolute Deviation of Reference Antenna PNR values.
-    Select antenna peak to noise (PNR) values that are below one normalised median deviation of the
-    antenna median PNR for best reference antenna selection. This ensures
-    that a subset of antennas with reasonable peak to noise are selected.
+    Select antenna peak to noise (PNR) values that are above the normalised median absolute
+    deviation (NMAD) Threshold for best reference antenna selection.
+    This ensures that a subset of antennas with reasonable peak to noise are selected.
 
     Parameters
     ----------

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -313,7 +313,7 @@ class Scan:
         if refant_index is not None:
             logger.info('Flag fraction on refant is > 80%% (%.3f%%),'
                         ' selecting a new refant', flag_frac)
-            if any(refant_order) == refant_index:
+            if refant_index in refant_order:
                 refant_order.remove(refant_index)
         return refant_order[0]
 

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -313,7 +313,8 @@ class Scan:
         if refant_index is not None:
             logger.info('Flag fraction on refant is > 80%% (%.3f%%),'
                         ' selecting a new refant', flag_frac)
-            refant_order.remove(refant_index)
+            if any(refant_order) == refant_index:
+                refant_order.remove(refant_index)
         return refant_order[0]
 
     # ---------------------------------------------------------------------------------------------

--- a/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/test/test_calprocs.py
@@ -812,3 +812,93 @@ class TestInterpolateSoln(unittest.TestCase):
         expected[:, 1, 2] = np.array([6, 8]) * np.exp(1.j * np.pi / 180 * np.array([30, 40]))
 
         np.testing.assert_almost_equal(out, expected, 6)
+
+
+class TestSelectMedDeviation(unittest.TestCase):
+    """Tests for :func:`katsdpcal.calprocs.select_med_deviation
+    This tests that the Median Absolute Deviation (MAD) threshold is correctly calulated
+    for even/odd PNR value arrays or where nans are present"""
+    def test_nan_pnr_values(self):
+        """Test that nan values are omitted in median absolute deviation calculation"""
+        self.array_med_pnr = np.array([1., np.nan, 3, 4, 5])
+        self.ant_indices = np.array([1, 4, 3, 2, 0])
+        median = 3.5
+        deviation_median = 1
+        self.mad_threshold = (median - deviation_median)
+
+        self.expected_mad_pnr = self.array_med_pnr > self.mad_threshold
+        self.expected_mad_pnr = self.expected_mad_pnr[self.ant_indices]
+        result_mad_pnr = calprocs.select_med_deviation_pnr_ants(self.array_med_pnr)
+        np.testing.assert_equal(self.expected_mad_pnr, result_mad_pnr)
+
+    def test_evenArray_pnr_values(self):
+        """Test that for an even array the MAD selection is correct"""
+        self.array_med_pnr = np.array([1, 2, 3, 4])
+        self.ant_indices = np.array([3, 2, 1, 0])
+        median = (2+3)/2
+        deviation_median = (0.5+1.5)/2
+        self.mad_threshold = (median - deviation_median)
+        # 1.5
+
+        self.expected_mad_pnr = self.array_med_pnr > self.mad_threshold
+        self.expected_mad_pnr = self.expected_mad_pnr[self.ant_indices]
+        result_mad_pnr = calprocs.select_med_deviation_pnr_ants(self.array_med_pnr)
+
+        np.testing.assert_equal(self.expected_mad_pnr, result_mad_pnr)
+
+    def test_oddArray_pnr_values(self):
+        """Test that for an odd array the MAD selection is correct"""
+        self.array_med_pnr = np.array([1, 2, 3, 4, 5])
+        self.ant_indices = np.array([4, 3, 2, 1, 0])
+        median = 3
+        deviation_median = 1
+        self.mad_threshold = (median - deviation_median)  # 2
+
+        self.expected_mad_pnr = self.array_med_pnr > self.mad_threshold
+        self.expected_mad_pnr = self.expected_mad_pnr[self.ant_indices]
+        result_mad_pnr = calprocs.select_med_deviation_pnr_ants(self.array_med_pnr)
+        np.testing.assert_equal(self.expected_mad_pnr, result_mad_pnr)
+
+
+class TestBestRefAnt(unittest.TestCase):
+    """Tests for :func:`katsdpcal.calprocs.best_refant"""
+    def setUp(self):
+        self.data = np.ones((10, 2, 10), np.complex64)
+        self.bls = np.array([[0, 0, 1, 0, 1, 2, 0, 1, 2, 3], [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]]).T
+        self.bandwidth = 856000000.0
+        self.chans = np.linspace(1e+9, 1.5e+9, 10)
+        self.freqs = np.arange(len(self.chans)) / self.chans * self.bandwidth + self.bandwidth
+        self.offset = np.pi/4
+        target = ('J1939-6342, radec, 19:39:25.03, -63:42:45.6,''(0.00408  0.00508 0.0708 0.0608)')
+        self.flux = katpoint.Target(target).flux_density(0.00408)
+        self.flux_array = np.array([self.flux])[:, np.newaxis]
+        self.rs = np.random.RandomState(seed=1)
+        k = self.rs.uniform(-50e-12, 50e-12, (2, 5))
+        pol1 = {0: {0: k[0][0], 1: k[0][1], 2: k[0][2], 3: k[0][3], 4: k[0][4]}}
+        pol2 = {1: {0: k[1][0], 1: k[1][1], 2: k[1][2], 3: k[1][3], 4: k[1][4]}}
+        self.delays = {'polv': pol1, 'polh': pol2}
+        baseline_delays = {}
+        for (a1, a2) in self.bls:
+            baseline_delays[(a1, a2)] = self.delays['polv'][0][a1] - self.delays['polh'][1][a2]
+        self.delay_array = np.array([baseline_delays[(ant1, ant2)] for (ant1, ant2) in self.bls])
+        self.vis_delay_offset = np.exp(2.j * np.pi * self.freqs[:, np.newaxis] * self.delay_array + self.offset)
+        self.data[:, 0, :] *= np.angle(self.vis_delay_offset)
+        noise = 0.1 * (self.rs.random_sample((10, 2, 10)) - 0.1)
+        self.data *= np.exp(1.j * noise)
+
+    def test_nan_antenna(self):
+        """Test that a nan antenna is not selected by best_refant"""
+
+        nan_antenna = [np.any(1 == x) for x in self.bls]
+        self.data[:, :, nan_antenna] = np.nan
+        result_ant_longest_bls = calprocs.best_refant(self.data, self.bls, self.chans)
+        assert 1 not in result_ant_longest_bls
+
+    def test_noisy_antenna(self):
+        """Test that a noisy antenna is not selected by best_refant"""
+
+        noisy_mask = (self.bls[:, 0] == 2) ^ (self.bls[:, 1] == 2)
+        extra_noise = 10 * (self.rs.random_sample((10, 4)) - 0.5)  # Higher noise level
+        self.data[:, 0, noisy_mask] *= np.exp(1.j * extra_noise)
+        result_ant_longest_bls = calprocs.best_refant(self.data, self.bls, self.chans)
+        assert 2 not in result_ant_longest_bls

--- a/katsdpcal/test/test_calprocs.py
+++ b/katsdpcal/test/test_calprocs.py
@@ -860,8 +860,8 @@ class TestBestRefAnt(unittest.TestCase):
 
         nan_antenna = [np.any(1 == x) for x in self.bls]
         self.vis[:, :, nan_antenna] = np.nan
-        result_ant_longest_bls = calprocs.best_refant(self.vis, self.bls, self.freqs)
-        assert 1 not in result_ant_longest_bls
+        candidate_ants = calprocs.best_refant(self.vis, self.bls, self.freqs)
+        assert 1 not in candidate_ants
 
     def test_noisy_antenna(self):
         """Test that a noisy antenna is not selected by best_refant"""
@@ -869,5 +869,5 @@ class TestBestRefAnt(unittest.TestCase):
         noisy_mask = (self.bls[:, 0] == 2) ^ (self.bls[:, 1] == 2)
         extra_noise = 10 * (self.rs.random_sample((10, 4)) - 0.5)  # Add higher noise level
         self.vis[:, 0, noisy_mask] *= np.exp(1.j * extra_noise)
-        result_ant_longest_bls = calprocs.best_refant(self.vis, self.bls, self.freqs)
-        assert 2 not in result_ant_longest_bls
+        candidate_ants = calprocs.best_refant(self.vis, self.bls, self.freqs)
+        assert 2 not in candidate_ants

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -648,7 +648,8 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         return value * ref_phase.conj()
 
     async def test_capture(self, expected_g=1, expected_BG_rtol=1e-2,
-                           expected_BCROSS_DIODE_rtol=1e-3):
+                           expected_BCROSS_DIODE_rtol=1e-3,
+                           expected_k_rtol=1e-3):
         """Tests the capture with some data, and checks that solutions are
         computed and a report written.
         """
@@ -744,7 +745,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         assert len(cal_product_K) == 1
         ret_K, ret_K_ts = cal_product_K[0]
         assert ret_K.dtype == np.float32
-        np.testing.assert_allclose(K - K[:, [0]], ret_K - ret_K[:, [0]], rtol=1e-3)
+        np.testing.assert_allclose(K - K[:, [0]], ret_K - ret_K[:, [0]], rtol=expected_k_rtol)
 
         # check SNR products are in telstate
         cal_product_SNR_K = telstate_cb_cal.get_range('product_SNR_K', st=0)
@@ -773,7 +774,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
             ret_KCROSS_DIODE, ret_KCROSS_DIODE_ts = cal_product_KCROSS_DIODE[0]
             assert ret_KCROSS_DIODE.dtype == np.float32
             np.testing.assert_allclose(K - K[1] - (ret_K - ret_K[1]),
-                                       ret_KCROSS_DIODE, rtol=1e-3)
+                                       ret_KCROSS_DIODE, rtol=expected_k_rtol)
             # Check BCROSS_DIODE
             ret_BCROSS_DIODE, ret_BCROSS_DIODE_ts = self.assemble_bandpass(telstate_cb_cal,
                                                                            'product_BCROSS_DIODE')
@@ -870,7 +871,8 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         # Relax the tolerances as the visibilities are generated using
         # the model given by the target string,
         # but calibration is performed using the full sky model.
-        await self.test_capture(expected_BG_rtol=5e-2, expected_BCROSS_DIODE_rtol=1e-2)
+        await self.test_capture(expected_BG_rtol=5e-2, expected_BCROSS_DIODE_rtol=1e-2,
+                                expected_k_rtol=3e-3)
 
     async def test_set_refant(self):
         """Tests the capture with a noisy antenna, and checks that the reference antenna is

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -649,7 +649,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
 
     async def test_capture(self, expected_g=1, expected_BG_rtol=1e-2,
                            expected_BCROSS_DIODE_rtol=1e-3,
-                           expected_k_rtol=1e-3):
+                           expected_K_rtol=1e-3):
         """Tests the capture with some data, and checks that solutions are
         computed and a report written.
         """
@@ -745,7 +745,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         assert len(cal_product_K) == 1
         ret_K, ret_K_ts = cal_product_K[0]
         assert ret_K.dtype == np.float32
-        np.testing.assert_allclose(K - K[:, [0]], ret_K - ret_K[:, [0]], rtol=expected_k_rtol)
+        np.testing.assert_allclose(K - K[:, [0]], ret_K - ret_K[:, [0]], rtol=expected_K_rtol)
 
         # check SNR products are in telstate
         cal_product_SNR_K = telstate_cb_cal.get_range('product_SNR_K', st=0)
@@ -774,7 +774,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
             ret_KCROSS_DIODE, ret_KCROSS_DIODE_ts = cal_product_KCROSS_DIODE[0]
             assert ret_KCROSS_DIODE.dtype == np.float32
             np.testing.assert_allclose(K - K[1] - (ret_K - ret_K[1]),
-                                       ret_KCROSS_DIODE, rtol=expected_k_rtol)
+                                       ret_KCROSS_DIODE, rtol=expected_K_rtol)
             # Check BCROSS_DIODE
             ret_BCROSS_DIODE, ret_BCROSS_DIODE_ts = self.assemble_bandpass(telstate_cb_cal,
                                                                            'product_BCROSS_DIODE')
@@ -872,7 +872,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         # the model given by the target string,
         # but calibration is performed using the full sky model.
         await self.test_capture(expected_BG_rtol=5e-2, expected_BCROSS_DIODE_rtol=1e-2,
-                                expected_k_rtol=3e-3)
+                                expected_K_rtol=3e-3)
 
     async def test_set_refant(self):
         """Tests the capture with a noisy antenna, and checks that the reference antenna is

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,9 @@ setup(
     platforms=["OS Independent"],
     keywords="kat kat7 meerkat ska",
     zip_safe=False,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     install_requires=[
-        "numpy>=1.15", "scipy>=0.17", "numba>=0.49.0",
+        "numpy>=1.15", "scipy>=1.5.0", "numba>=0.49.0",
         "dask[array,distributed]>=1.1.0", "distributed>=2.2.0", "bokeh",
         "attrs", "sortedcontainers",
         "aiokatcp", "astropy", "async_timeout",


### PR DESCRIPTION
This is a new PR for reference antenna selection as per the initial investigation done in [SPR1-1964](https://skaafrica.atlassian.net/browse/SPR1-1964). We have restarted the PR for this ticket (previous one in `select_mad-ref_antenna` ), as a better way to deal with previous commits, also this PR is branched of the updated `master`.

A `select_med_deviation_pnr_ants` function has been added to calculate the median deviation of antenna peak-to-noise (PNR) values, this function returns an array of antenna indices that have a relatively good PNR. We have considered antenna PNRs that are one normalized deviation below the median  as being relatively high quality antennas for selection as the reference antenna. The `best_refant`, which is the function that calculates the PNR across antennas, has been modified to call the `select_med_deviation_pnr_ants` and thereafter return the corresponding best antenna solution for the reference antenna selection.
The `test_calprocs.py` contains the corresponding unit tests for the new solution in `select_med_deviation_pnr_ants` and `best_refant` . The changes in `scan.py` is the addition of a conditional statement (previous PR review) that checks and updates if the refant is in the antenna index list of the `best_refant` function output.

[SPR1-1964]: https://skaafrica.atlassian.net/browse/SPR1-1964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ