### PR TITLE
SPR1-3025: Integrate reference pointing with cal pipeline

### DIFF
--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_L_narrow_107.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_L_narrow_107.txt
@@ -31,3 +31,6 @@ rfi_freq_chunks : 8                  # No of chunks to divide band into when est
 bcross_sky_knots : 856, 856, 856, 856, 963, 1070, 1284, 1525, 1608, 1658, 1711, 1711, 1711, 1711                     # knots in MHz
 bcross_sky_coefs : 1.507, 15.957, 13.683, 21.0169, 21.793, 26.879, 32.611, 32.973, 66.216, 16.998, 0,  0,  0,  0     # coefs of fit (in degrees)
 bcross_sky_k : 3                                                                                                     # degree of spline
+
+# pointing calibration
+epoint_freq_chunks : 16              # No of chunks to divide band into when fitting beams

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_L_narrow_54.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_L_narrow_54.txt
@@ -31,3 +31,6 @@ rfi_freq_chunks : 8                  # No of chunks to divide band into when est
 bcross_sky_knots : 856, 856, 856, 856, 963, 1070, 1284, 1525, 1608, 1658, 1711, 1711, 1711, 1711                     # knots in MHz
 bcross_sky_coefs : 1.507, 15.957, 13.683, 21.0169, 21.793, 26.879, 32.611, 32.973, 66.216, 16.998, 0,  0,  0,  0     # coefs of fit (in degrees)
 bcross_sky_k : 3                                                                                                     # degree of spline
+
+# pointing calibration
+epoint_freq_chunks : 16              # No of chunks to divide band into when fitting beams

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_L_wide.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_L_wide.txt
@@ -30,3 +30,6 @@ rfi_freq_chunks : 8                  # No of chunks to divide band into when est
 bcross_sky_knots : 856, 856, 856, 856, 963, 1070, 1284, 1525, 1608, 1658, 1711, 1711, 1711, 1711                     # knots in MHz
 bcross_sky_coefs : 1.507, 15.957, 13.683, 21.0169, 21.793, 26.879, 32.611, 32.973, 66.216, 16.998, 0,  0,  0,  0     # coefs of fit (in degrees)
 bcross_sky_k : 3                                                                                                     # degree of spline
+
+# pointing calibration
+epoint_freq_chunks : 16              # No of chunks to divide band into when fitting beams

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S_narrow.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S_narrow.txt
@@ -30,3 +30,6 @@ rfi_freq_chunks : 8                  # No of chunks to divide band into when est
 bcross_sky_knots : 1750, 1968, 2188, 2628, 3124, 3294, 3394, 3500      # knots in MHz
 bcross_sky_coefs : 0, 0, 0, 0, 0, 0, 0, 0, 0                           # coefs of fit (in degrees)
 bcross_sky_k : 3
+
+# pointing calibration
+epoint_freq_chunks : 16              # No of chunks to divide band into when fitting beams

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S_wide.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_S_wide.txt
@@ -31,3 +31,6 @@ rfi_freq_chunks : 8                  # No of chunks to divide band into when est
 bcross_sky_knots : 1750, 1968, 2188, 2628, 3124, 3294, 3394, 3500      # knots in MHz
 bcross_sky_coefs : 0, 0, 0, 0, 0, 0, 0, 0, 0                           # coefs of fit (in degrees)
 bcross_sky_k : 3
+
+# pointing calibration
+epoint_freq_chunks : 16              # No of chunks to divide band into when fitting beams

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_UHF_narrow.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_UHF_narrow.txt
@@ -30,3 +30,6 @@ rfi_freq_chunks : 8                  # No of chunks to divide band into when est
 bcross_sky_knots : 544, 544, 544, 544, 563, 571, 578, 612, 680, 816, 870, 899, 914, 952, 971, 986, 1003, 1020, 1050, 1057, 1071, 1088, 1088, 1088, 1088      # knots in MHz
 bcross_sky_coefs : 15.44, 14.86, 14.05, 13.62, 12.5, 11.3, 11.35, 13.57, 13.97, 14.27, 14.88, 15.26, 16.32, 17.01, 17.52, 19.25, 21.14, 23.54, 24.51, 25.83, 26.36, 0.0, 0.0, 0.0, 0.0    # coefs of fit (in degrees)
 bcross_sky_k : 3
+
+# pointing calibration
+epoint_freq_chunks : 16              # No of chunks to divide band into when fitting beams

--- a/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_UHF_wide.txt
+++ b/katsdpcal/conf/pipeline_params/pipeline_parameters_meerkat_UHF_wide.txt
@@ -30,3 +30,6 @@ rfi_freq_chunks : 8                  # No of chunks to divide band into when est
 bcross_sky_knots : 544, 544, 544, 544, 563, 571, 578, 612, 680, 816, 870, 899, 914, 952, 971, 986, 1003, 1020, 1050, 1057, 1071, 1088, 1088, 1088, 1088      # knots in MHz
 bcross_sky_coefs : 15.44, 14.86, 14.05, 13.62, 12.5, 11.3, 11.35, 13.57, 13.97, 14.27, 14.88, 15.26, 16.32, 17.01, 17.52, 19.25, 21.14, 23.54, 24.51, 25.83, 26.36, 0.0, 0.0, 0.0, 0.0    # coefs of fit (in degrees)
 bcross_sky_k : 3                                                                                                                                             # degree of spline
+
+# pointing calibration
+epoint_freq_chunks : 16              # No of chunks to divide band into when fitting beams

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1142,6 +1142,8 @@ class Pipeline(Task):
     def flush_pipeline(self, capture_block_id):
         telstate_cb_cal = make_telstate_cb(self.telstate_cal, capture_block_id)
         flush_pipeline(telstate_cb_cal, self.parameters, self.solution_stores)
+        # Wipe out intermediate B solutions for reference pointing after fitting beams
+        self.solution_stores['B_POINTING'] = solutions.CalSolutionStore('B')
 
     def get_measured_flux(self, event):
         # Get the flux densities of the gain calibrators

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -1089,7 +1089,8 @@ class Pipeline(Task):
             'B': solutions.CalSolutionStoreLatest('B'),
             'BCROSS_DIODE': solutions.CalSolutionStoreLatest('BCROSS_DIODE'),
             'G': solutions.CalSolutionStore('G'),
-            'G_FLUX': solutions.CalSolutionStore('G')
+            'G_FLUX': solutions.CalSolutionStore('G'),
+            'B_POINTING': solutions.CalSolutionStore('B')
         }
 
     def _reset_refant(self):

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -140,7 +140,9 @@ USER_PARAMS_CHANS = [
               telstate=False),
     Parameter('bcross_sky_coefs', 'coefs for bcross_sky spline fit across frequency',
               comma_list(float), telstate=False),
-    Parameter('bcross_sky_k', 'degree of spline fit for bcross_sky', int, telstate=False)
+    Parameter('bcross_sky_k', 'degree of spline fit for bcross_sky', int, telstate=False),
+    Parameter('epoint_freq_chunks', 'no of chunks to divide band into when fitting beams', int,
+              converter=FreqChunksConverter),
 ]
 
 

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -179,6 +179,8 @@ COMPUTED_PARAMETERS = [
     Parameter('product_names', 'names to use in telstate for solutions', dict),
     Parameter('product_B_parts', 'number of separate keys forming bandpass solution', int,
               telstate=True),
+    Parameter('product_EPOINT_parts', 'number of separate keys forming beam fit solution', int,
+              telstate=True),
     Parameter('servers', 'number of parallel servers', int),
     Parameter('server_id', 'identity of this server (zero-based)', int),
     Parameter('bcross_sky_spline', 'spline fit to bcross_sky across frequency (in MHz)', tuple,
@@ -506,7 +508,7 @@ def finalise_parameters(parameters, telstate_l0, servers, server_id):
         'EPOINT': 'product_EPOINT{}'.format(server_id),
         'SNR_EPOINT': 'product_SNR_EPOINT{}'.format(server_id),
     }
-    parameters['product_B_parts'] = servers
+    parameters['product_B_parts'] = parameters['product_EPOINT_parts'] = servers
 
     # Convert spline knots, coefs and degrees into spline tuple to store in telstate
     parameters['bcross_sky_spline'] = (np.array(parameters['bcross_sky_knots']),

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -502,7 +502,9 @@ def finalise_parameters(parameters, telstate_l0, servers, server_id):
         'B': 'product_B{}'.format(server_id),
         'SNR_B': 'product_SNR_B{}'.format(server_id),
         'BCROSS_DIODE': 'product_BCROSS_DIODE{}'.format(server_id),
-        'BCROSS_DIODE_SKY': 'product_BCROSS_DIODE_SKY{}'.format(server_id)
+        'BCROSS_DIODE_SKY': 'product_BCROSS_DIODE_SKY{}'.format(server_id),
+        'EPOINT': 'product_EPOINT{}'.format(server_id),
+        'SNR_EPOINT': 'product_SNR_EPOINT{}'.format(server_id)
     }
     parameters['product_B_parts'] = servers
 

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -767,13 +767,13 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 # save to G
                 save_solution(None, None, solution_stores['G'], g_soln)
         
-        #POINTING
+        # POINTING
         if any('pointingcal' in k for k in taglist):
             # B solution on pointing cal while dishes are offset
             logger.info('Solving for B on pointing calibrator %s', target_name)
-            p_soln = s.b_sol(bp0_h)
+            b_soln = s.b_sol(bp0_h)
             # Save only to solution stores
-            solution_stores['B_POINTING'].add(p_soln)
+            solution_stores['B_POINTING'].add(b_soln)
 
         # GAIN
         if any('gaincal' in k for k in taglist):

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -903,9 +903,8 @@ def get_offsets(ts, parameters, target, t_stamps, temp, pres, humi):
 
 def _finish_pointing_cal(ts, parameters, b_solutions):
     """Complete pointing calibration by fitting beams to B gains and saving to telstate."""
-    # TODO: num_chunks should enter through parameters
-    # Group the frequency channels into this many sections
-    num_chunks = 16
+    # Group the global frequency channels into this many sections (fewer per server)
+    num_chunks = parameters['epoint_freq_chunks']
     # Extract some some commonly used constants from the TS and parameters
     # Middle time for each dump
     mid_times = b_solutions.times

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -948,11 +948,12 @@ def flush_pipeline(ts, parameters, solution_stores):
     beam_sol_SNR = np.full((num_chunks, len(pols), len(ants), 5), np.nan, dtype=np.float32)
     for a, ant in enumerate(ts.cal_antlist):
         for c,beam in enumerate(beams[ant]):
-            beam_sol[c,:,a]=np.r_[beam.center, beam.width, beam.height]
-            beam_sol_SNR[c,:,a]=1/np.r_[beam.std_center, beam.std_width, beam.std_height]
+            if beam is None:
+                continue
+            beam_sol[c,:,a] = np.r_[beam.center, beam.width, beam.height]
+            beam_sol_SNR[c,:,a] = 1 / np.r_[beam.std_center, beam.std_width, beam.std_height]
             if not beam.is_valid:
-                beam_sol[c,:,a]=np.r_[beam.center, beam.width, beam.height]
-                beam_sol_SNR[c, :, a, 4] = 0.0
+                beam_sol_SNR[c, :, a, -1] = 0.0
     beam_sol=solutions.CalSolution(soltype='B', soltime=soltime, solvalues=beam_sol, 
                                    soltarget=target.name, solsnr=beam_sol_SNR)
     # Save fitted beam CalSolution and beam SNR to telstate as 

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -913,15 +913,13 @@ def flush_pipeline(ts, parameters, solution_stores):
         The pipeline parameters
     solution_stores : dict of :class:`~.CalSolutionStore`-like
         Solution stores for the capture block, indexed by solution type
-    num_chunks : int, optional
-        Group the frequency channels into this many sections to obtain
-        pointing fits
-
+        
     Returns
     -------
     Beam solutions saved to telstate
     """
     # TODO: num_chunks should enter through paramters
+    #Group the frequency channels into this many sections
     num_chunks = 16
     # Extract bandpass gains from solution stores
     b_solutions = solution_stores['B_POINTING'].get_range(start_time=0, end_time = time.time()).values

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -902,7 +902,7 @@ def get_offsets(ts, target, t_stamps, temp, pres, humi, parameters):
     return offsets
 
 
-def flush_pipeline(ts, parameters, solution_stores, num_chunks=16):
+def flush_pipeline(ts, parameters, solution_stores):
     """Secondary pipeline calibration.
 
     Parameters
@@ -921,7 +921,8 @@ def flush_pipeline(ts, parameters, solution_stores, num_chunks=16):
     -------
     Beam solutions saved to telstate
     """
-    # POINTING
+    # TODO: num_chunks should enter through paramters
+    num_chunks = 16
     # Extract bandpass gains from solution stores
     b_solutions = solution_stores['B_POINTING'].get_range(start_time=0, end_time = time.time()).values
     # Extract some some commonly used constants from the TS and parameters
@@ -962,5 +963,6 @@ def flush_pipeline(ts, parameters, solution_stores, num_chunks=16):
     beam_sol=solutions.CalSolution(soltype='P', soltime=soltime, solvalues=beam_sol, soltarget=target.name)
     beam_sol_SNR = solutions.CalSolution(soltype='P', soltime=soltime, solvalues=beam_sol_SNR, soltarget=target.name)
     # Save fitted beam CalSolution and beam SNR to telstate as 
-    save_solution(ts, 'product_EPOINT', None, beam_sol)
-    save_solution(ts, 'product_SNR_EPOINT', None, beam_sol_SNR)
+    save_solution(ts, parameters['product_names']['product_EPOINT'], None, beam_sol)
+    save_solution(ts, parameters['product_names']['product_SNR_EPOINT'], None, beam_sol_SNR)
+   

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -766,6 +766,14 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 # If there is no model and the target isn't a gaincal as well
                 # save to G
                 save_solution(None, None, solution_stores['G'], g_soln)
+        
+        #POINTING
+        if any('pointingcal' in k for k in taglist):
+            # P solution
+            logger.info('Solving for P on pointing calibrator %s', target_name)
+            p_soln = s.b_sol(bp0_h)
+            # Save only to solution stores
+            solution_stores['B_POINTING'].add(p_soln)
 
         # GAIN
         if any('gaincal' in k for k in taglist):

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -939,7 +939,7 @@ def flush_pipeline(ts, parameters, solution_stores):
     # Calculate offset (x,y) co-ordinates for each pointing
     offsets = get_offsets(ts, parameters, target, mid_times, temp, pres, humi)
     # Extract gains per pointing offset, per receptor and per frequency chunk.
-    data_points = pointing.get_offset_gains(b_solutions.values(), offsets, ants, channel_freqs,
+    data_points = pointing.get_offset_gains(b_solutions.values, offsets, ants, channel_freqs,
                                              pols, num_chunks)
     # Fit primary beams to the gains
     beams = pointing.beam_fit(data_points, ants, num_chunks)
@@ -948,11 +948,8 @@ def flush_pipeline(ts, parameters, solution_stores):
     beam_sol_SNR = np.full((num_chunks, len(pols), len(ants), 5), np.nan, dtype=np.float32)
     for a, ant in enumerate(ts.cal_antlist):
         for c,beam in enumerate(beams[ant]):
-            if beam is None:
-                continue
-            if beam.is_valid:
-                beam_sol[c,:,a]=np.r_[beam.center, beam.width, beam.height]
-                beam_sol_SNR[c,:,a]=1/np.r_[beam.std_center, beam.std_width, beam.std_height]
+            beam_sol[c,:,a]=np.r_[beam.center, beam.width, beam.height]
+            beam_sol_SNR[c,:,a]=1/np.r_[beam.std_center, beam.std_width, beam.std_height]
             if not beam.is_valid:
                 beam_sol[c,:,a]=np.r_[beam.center, beam.width, beam.height]
                 beam_sol_SNR[c, :, a, 4] = 0.0

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -902,7 +902,12 @@ def get_offsets(ts, parameters, target, t_stamps, temp, pres, humi):
 
 
 def _finish_pointing_cal(ts, parameters, b_solutions):
-    """Complete pointing calibration by fitting beams to B gains and saving to telstate."""
+    """Complete pointing calibration by fitting beams to B gains and saving to telstate.
+
+    Uses katsdpcalproc routines to fit primary beams using banpass solutions 
+    generated on previous target tracks and saves beam solutions to telstate
+    as calibration product EPOINT
+    """
     # Group the global frequency channels into this many sections (fewer per server)
     num_chunks = parameters['epoint_freq_chunks']
     # Extract some some commonly used constants from the TS and parameters

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -7,6 +7,7 @@ from numbers import Integral
 
 import numpy as np
 import katsdptelstate
+from katsdpcalproc import pointing
 
 from collections import defaultdict
 from katdal.sensordata import TelstateSensorGetter, SensorCache
@@ -845,9 +846,56 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
 
     return target_slices, av_corr
 
+def get_offsets(ts, target, t_stamps, temp, pres, humi, parameters):
 
-def flush_pipeline(ts, parameters, solution_stores):
-    """Flush pending calibration products in pipeline.
+
+    """Calculate offset co-odinates relative to target for each pointing.
+
+    Parameters
+    ----------
+    ts : :class:`katsdptelstate.TelescopeState`
+        Telescope state, scoped to the cal namespace within the capture block
+    target : :class:`katpoint.Target`
+        Pointing calibrator as a katpoint target object
+    t_stamps : list
+        Timestamps at which offset co-ordinates must be determined
+    temp, pres, humi : :class: 'float'
+        Atmospheric conditions used for refraction correction
+    parameters : dict
+        The pipeline parameters
+
+    Returns
+    -------
+    offsets : list of (x,y) co-ordinates for each pointing
+    """
+    rc=katpoint.RefractionCorrection()
+    # Set refant index
+    refant_ind = parameters['refant_index']
+    refant = parameters['antennas'][refant_ind]
+    # Get middle timestamp of each track slice
+    offsets=[]
+    for j in t_stamps:
+        # AZ/EL co-ordinates of target
+        azel=target.azel(timestamp=j, antenna=refant)
+        # apply refraction to target co-ordinates (already in radians)
+        ref_corr_el = rc.apply(azel[1], temp, pres, humi)
+        # Construct target object
+        trgt = katpoint.construct_azel_target(azel[0], ref_corr_el)
+        # Get offset az/el co-ordiantes (direction in which reference antenna is pointing)
+        az = ts.get_range(str(refant.name)+'_pos_actual_scan_azim', et=j )
+        el = ts.get_range(str(refant.name)+'_pos_actual_scan_elev', et=j )
+        az_actual = katpoint.deg2rad(az[0][0])
+        el_actual = rc.apply(katpoint.deg2rad(el[0][0]), temp, pres, humi)
+        # Project spherical coordinates to plane with target position as reference
+        offset = trgt.sphere_to_plane(az_actual,el_actual, coord_system='azel', antenna=refant, timestamp=j)
+        offset = (katpoint.rad2deg(offset[0]),katpoint.rad2deg(offset[1]))
+        offsets.append(offset)
+
+    return offsets
+
+
+def flush_pipeline(ts, parameters, solution_stores, num_chunks=16):
+    """Secondary pipeline calibration.
 
     Parameters
     ----------
@@ -857,6 +905,54 @@ def flush_pipeline(ts, parameters, solution_stores):
         The pipeline parameters
     solution_stores : dict of :class:`~.CalSolutionStore`-like
         Solution stores for the capture block, indexed by solution type
+    num_chunks : int, optional
+        Group the frequency channels into this many sections to obtain
+        pointing fits
+
+    Returns
+    -------
+    Beam solutions saved to telstate
     """
-    logger.info('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-    logger.info('Flushed pipeline')
+    # POINTING
+    # Extract bandpass gains from solution stores
+    b_solutions = solution_stores['B_POINTING'].get_range(start_time=0, end_time = time.time()).values
+    # Extract some some commonly used constants from the TS and parameters
+    # Middle time for each dump
+    mid_times = b_solutions.get_range(start_time = 0, end_time= time.time()).times
+    target_str = ts.get_range('cbf_target', et = mid_times[-1])[0][0]
+    target = katpoint.Target(target_str)
+    # Atmospheric conditions
+    pres = ts.get_range('anc_air_pressure', et = mid_times[-1])[0][0]
+    temp = ts.get_range('anc_air_temperature', et = mid_times[-1])[0][0]
+    humi = ts.get_range('anc_air_relative_humidity', et = mid_times[-1])[0][0]
+    ants = parameters['antennas']
+    dump_period = ts['int_time']
+    channel_freqs = parameters['channel_freqs']
+    pols = parameters['pol_ordering']
+    
+    # Calculate offset (x,y) co-ordinates for each pointing
+    offsets = get_offsets(ts, b_solutions, target, mid_times, temp, pres, humi, parameters)
+    # Extract gains per pointing offset, per receptor and per frequency chunk.
+    data_points = pointing.get_offset_gains(b_solutions, offsets, ants, dump_period,
+                     channel_freqs, pols, num_chunks)
+    # Fit primary beams to the gains
+    beams = pointing.beam_fit(data_points, ants, num_chunks, beam_center=(0.5, 0.5))
+    # Save fitted beams as CalSolution with shape (num_chunks, len(pols), len(ants), 5)
+    beam_sol = np.full((num_chunks, len(pols), len(ants), 5), np.nan)
+    beam_sol_SNR = np.full((num_chunks, len(pols), len(ants), 5), np.nan)
+    for a, ant in enumerate(ts.cal_antlist):
+        for c,chunk in enumerate(beams[ant]):
+            if chunk is None:
+                continue
+            if chunk.is_valid:
+                beam_sol[c,:,a]=np.r_[chunk.center, chunk.width, chunk.height]
+                beam_sol_SNR[c,:,a]=1/np.r_[chunk.center, chunk.width, chunk.height]
+            else:
+                beam_sol[c,:,a]=np.r_[chunk.center, chunk.width, np.nan]
+                beam_sol_SNR[c,:,a]=1/np.r_[chunk.center, chunk.width, chunk.height]
+    soltime = np.mean(mid_times)
+    beam_sol=solutions.CalSolution(soltype='P', soltime=soltime, solvalues=beam_sol, soltarget=target.name)
+    beam_sol_SNR = solutions.CalSolution(soltype='P', soltime=soltime, solvalues=beam_sol_SNR, soltarget=target.name)
+    # Save fitted beam CalSolution and beam SNR to telstate as 
+    save_solution(ts, 'product_EPOINT', None, beam_sol)
+    save_solution(ts, 'product_SNR_EPOINT', None, beam_sol_SNR)

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -918,7 +918,6 @@ def _finish_pointing_cal(ts, parameters, b_solutions):
     temp = ts.get_range('anc_air_temperature', et = soltime)[0][0]
     humi = ts.get_range('anc_air_relative_humidity', et = soltime)[0][0]
     ants = parameters['antennas']
-    dump_period = ts['int_time']
     channel_freqs = parameters['channel_freqs']
     pols = parameters['pol_ordering']
     
@@ -932,8 +931,8 @@ def _finish_pointing_cal(ts, parameters, b_solutions):
     # Save fitted beams as CalSolution with shape (num_chunks, len(pols), len(ants), 5)
     beam_sol = np.full((num_chunks, len(pols), len(ants), 5), np.nan, dtype=np.float32)
     beam_sol_SNR = np.full((num_chunks, len(pols), len(ants), 5), np.nan, dtype=np.float32)
-    for a, ant in enumerate(ts.cal_antlist):
-        for c,beam in enumerate(beams[ant]):
+    for a, ant in enumerate(ants):
+        for c, beam in enumerate(beams[ant.name]):
             if beam is None:
                 continue
             beam_sol[c,:,a] = np.r_[beam.center, beam.width, beam.height]

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -938,9 +938,9 @@ def _finish_pointing_cal(ts, parameters, b_solutions):
             beam_sol_SNR[c,:,a] = 1 / np.r_[beam.std_center, beam.std_width, beam.std_height]
             if not beam.is_valid:
                 beam_sol_SNR[c, :, a, -1] = 0.0
-    beam_sol=solutions.CalSolution(soltype='B', soltime=soltime, solvalues=beam_sol, 
-                                   soltarget=target.name, solsnr=beam_sol_SNR)
-    # Save fitted beam CalSolution and beam SNR to telstate as 
+    beam_sol = solutions.CalSolution(soltype='EPOINT', soltime=soltime, solvalues=beam_sol,
+                                     soltarget=target.name, solsnr=beam_sol_SNR)
+    # Save fitted beam CalSolution and beam SNR to telstate
     save_solution(ts, parameters['product_names']['EPOINT'], None, beam_sol)
 
 
@@ -965,9 +965,5 @@ def flush_pipeline(ts, parameters, solution_stores):
     b_solutions = solution_stores['B_POINTING'].get_range(start_time=0, end_time=time.time())
     n_pointings = len(b_solutions.times)
     if n_pointings > 0:
-        logger.info(
-            'Finishing pointing cal on target %r (%d pointings)',
-            b_solutions.target,
-            n_pointings
-        )
+        logger.info('Finishing pointing cal on %d pointings', n_pointings)
         _finish_pointing_cal(ts, parameters, b_solutions)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -959,16 +959,16 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
 
         # Updating pos_actual_scan_azim/elev every 0.5 seconds (4 times per dump)
         pos_sensor_period = 0.5
-        num_pos_updates = self.dump_period / pos_sensor_period
+        num_pos_updates = int(np.round(self.dump_period / pos_sensor_period))
         start_time = self.first_dump_ts- (0.5* self.dump_period)
         for ant in ant_objects:
             ts = start_time
             for offset in offsets:
-                for i in range(num_pos_updates * (n_track + n_slew) / n_pointing):
+                for i in range(num_pos_updates * (n_track + n_slew) // n_pointing):
                     #update pos_actual_scan 8 times per dump period, ie. every 0.5 seconds
                     azel = target.plane_to_sphere(katpoint.deg2rad(offset[0]), katpoint.deg2rad(offset[1]), 
-                                                antenna=ant_objects[0], timestamp=ts)
-                    azel = [katpoint.wrap_angle(azel[0]), azel[1]]
+                                                antenna=ant, timestamp=ts)
+                    azel = [katpoint.rad2deg(katpoint.wrap_angle(azel[0])), katpoint.rad2deg(azel[1])]
                     self.telstate.add(ant.name +'_pos_actual_scan_azim', azel[0], ts=ts)
                     self.telstate.add(ant.name +'_pos_actual_scan_elev', azel[1], ts=ts)
                     ts = ts + (self.dump_period/8)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -1001,12 +1001,14 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
         # Asserting dtypes, shape of cal product
         if 'pointingcal' in target.tags:
+            num_chunks = telstate_cb_cal['param_epoint_freq_chunks']
             for i in range(self.n_servers):
                 cal_product_EPOINTn = telstate_cb_cal.get_range('product_EPOINT{}'.format(i), st=0)
                 assert len(cal_product_EPOINTn) == 1
                 ret_EPOINTn, ret_EPOINTn_ts = cal_product_EPOINTn[0]
                 assert ret_EPOINTn.dtype == np.float32
-                assert ret_EPOINTn.shape == (16 // self.n_servers, 2, self.n_antennas, 5)
+                assert ret_EPOINTn.shape == (num_chunks // self.n_servers, 2, self.n_antennas, 5)
+            assert 'product_EPOINT{}'.format(self.n_servers) not in telstate_cb_cal
 
     async def test_set_refant(self):
         """Tests the capture with a noisy antenna, and checks that the reference antenna is

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -933,20 +933,20 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                   '13:31:08.29, +30:30:33.0, (0 50e3 0.1823 1.4757 -0.4739 0.0336)')
         self.telstate.add('cbf_target', target, ts=0.003)
         target = katpoint.Target(self.telstate.cbf_target)
-
+        telstate_cb = self.telstate.view('cb')
         # Adding track, track, slew obs activities for each offset
         n_activity=0
         for pointing in range(0,n_pointing):
-            self.telstate_cb.add('obs_activity', 'track',
+            telstate_cb.add('obs_activity', 'track',
                             ts=self.first_dump_ts + (n_activity - 0.5) * self.dump_period)
-            print(self.telstate_cb['obs_activity'])
+            print(telstate_cb['obs_activity'])
             
-            self.telstate_cb.add('obs_activity', 'slew',
+            telstate_cb.add('obs_activity', 'slew',
                             ts=self.first_dump_ts + ((n_activity + 2) - 0.5) * self.dump_period)
-            print(self.telstate_cb['obs_activity'])
+            print(telstate_cb['obs_activity'])
             n_activity+=3
 
-        self.telstate_cb.add('obs_activity', 'await_pipeline',
+        telstate_cb.add('obs_activity', 'await_pipeline',
                                 ts=self.first_dump_ts + ((n_track+n_slew) - 0.5) * self.dump_period)
         
         # Creating antenna objects

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -914,6 +914,91 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         # but calibration is performed using the full sky model.
         await self.test_capture(expected_BG_rtol=5e-2, expected_BCROSS_DIODE_rtol=1e-2,
                                 expected_K_rtol=3e-3)
+        
+    async def test_reference_pointing_capture(self):
+        """Tests the reference pointing feature with some data, and checks that 
+        solutions are computed and checks dtypes and shapes.
+        """
+        # Number of dumps spent tracking, slewing and awaiting
+        n_track = 16
+        n_slew = 8
+        n_await = 3
+        # Number of pointings
+        n_pointing = 8
+        n_times = n_track + n_await
+        rs = np.random.RandomState(seed=1)
+        
+        # Create target with pointingcal tag
+        target = ('J1331+3030, radec pointingcal, '
+                  '13:31:08.29, +30:30:33.0, (0 50e3 0.1823 1.4757 -0.4739 0.0336)')
+        self.telstate.add('cbf_target', target, ts=0.003)
+        target = katpoint.Target(self.telstate.cbf_target)
+
+        # Adding track, track, slew obs activities for each offset
+        n_activity=0
+        for pointing in range(0,n_pointing):
+            self.telstate_cb.add('obs_activity', 'track',
+                            ts=self.first_dump_ts + (n_activity - 0.5) * self.dump_period)
+            print(self.telstate_cb['obs_activity'])
+            
+            self.telstate_cb.add('obs_activity', 'slew',
+                            ts=self.first_dump_ts + ((n_activity + 2) - 0.5) * self.dump_period)
+            print(self.telstate_cb['obs_activity'])
+            n_activity+=3
+
+        self.telstate_cb.add('obs_activity', 'await_pipeline',
+                                ts=self.first_dump_ts + ((n_track+n_slew) - 0.5) * self.dump_period)
+        
+        # Creating antenna objects
+        ants=[self.telstate[a+"_observer"] for a in self.antennas]
+        ant_objects=[katpoint.Antenna(a) for a in ants]
+        
+        max_extent=1
+        # Build up sequence of pointing offsets running linearly in x and y directions
+        scan = np.linspace(-max_extent, max_extent, n_pointing// 2)
+        offsets_along_x = np.c_[scan, np.zeros_like(scan)]
+        offsets_along_y = np.c_[np.zeros_like(scan), scan]
+        offsets = np.r_[offsets_along_y, offsets_along_x]
+
+        # Updating pos_actual_scan_azim/elev every 0.5 seconds (4 times per dump)
+        start_time=self.first_dump_ts- (0.5* self.dump_period)
+        ts=start_time
+        for offset in offsets:
+            for i in range(0,n_pointing):
+                #update pos_actual_scan 8 times per dump period, ie. every 0.5 seconds
+                #use first antenna as reference antenna
+                azel=target.plane_to_sphere(katpoint.deg2rad(offset[0]), katpoint.deg2rad(offset[1]), 
+                                            antenna=ant_objects[0], timestamp=ts)
+                azel=[katpoint.wrap_angle(azel[0]), katpoint.wrap_angle(azel[1])]
+                self.telstate.add(str(ant_objects[0].name)+'_pos_actual_scan_azim', azel[0], ts=ts)
+                self.telstate.add(str(ant_objects[0].name)+'_pos_actual_scan_elev', azel[1], ts=ts)
+                ts = ts + (self.dump_period/8)
+
+        # Creating antenna delays and gains
+        K = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
+        G = rs.uniform(2.0, 4.0, (2, self.n_antennas)) + 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas))
+
+        # Making visibilities and preparing + sending heaps
+        vis=self.make_vis(K,G,target)
+        heaps = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis)
+        for endpoint, heap in heaps:
+            self.l0_streams[endpoint].send_heap(heap)
+        await self.make_request('capture-init', 'cb')
+        await asyncio.sleep(1)
+
+        for stream in self.l0_streams.values():
+            stream.send_heap(self.ig.get_end())
+        await self.shutdown_servers(180)
+
+        telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
+        # Asserting dtypes, shape of cal product
+        if 'pointingcal' in target.tags:
+            for i in range(self.n_servers):
+                cal_product_EPOINTn = telstate_cb_cal.get_range('product_EPOINT'+'{}'.format(i), st=0)
+                assert len(cal_product_EPOINTn) == 1
+                EPOINTn = cal_product_EPOINTn[0]
+                assert EPOINTn.dtype == np.float64
+                assert EPOINTn.shape == (16 // self.n_servers, 2, self.n_antennas, 5)
 
     async def test_set_refant(self):
         """Tests the capture with a noisy antenna, and checks that the reference antenna is

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -962,6 +962,10 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         offsets_along_x = np.c_[scan, np.zeros_like(scan)]
         offsets_along_y = np.c_[np.zeros_like(scan), scan]
         offsets = np.r_[offsets_along_y, offsets_along_x]
+        # Add atmospheric conditions
+        self.telstate.add('anc_air_pressure', 901.8, ts=0)
+        self.telstate.add('anc_air_temperature', 15.9, ts=0)
+        self.telstate.add('anc_air_relative_humidity', 22.3, ts=0)
 
         # Updating pos_actual_scan_azim/elev every 0.5 seconds (4 times per dump)
         pos_sensor_period = 0.5

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -950,10 +950,10 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                                 ts=self.first_dump_ts + ((n_track+n_slew) - 0.5) * self.dump_period)
         
         # Creating antenna objects
-        ants=[self.telstate[a+"_observer"] for a in self.antennas]
-        ant_objects=[katpoint.Antenna(a) for a in ants]
+        ants = [self.telstate[a+"_observer"] for a in self.antennas]
+        ant_objects = [katpoint.Antenna(a) for a in ants]
         
-        max_extent=1
+        max_extent = 1
         # Build up sequence of pointing offsets running linearly in x and y directions
         scan = np.linspace(-max_extent, max_extent, n_pointing// 2)
         offsets_along_x = np.c_[scan, np.zeros_like(scan)]
@@ -961,15 +961,15 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         offsets = np.r_[offsets_along_y, offsets_along_x]
 
         # Updating pos_actual_scan_azim/elev every 0.5 seconds (4 times per dump)
-        start_time=self.first_dump_ts- (0.5* self.dump_period)
-        ts=start_time
+        start_time = self.first_dump_ts- (0.5* self.dump_period)
+        ts = start_time
         for offset in offsets:
             for i in range(0,n_pointing):
                 #update pos_actual_scan 8 times per dump period, ie. every 0.5 seconds
                 #use first antenna as reference antenna
-                azel=target.plane_to_sphere(katpoint.deg2rad(offset[0]), katpoint.deg2rad(offset[1]), 
+                azel = target.plane_to_sphere(katpoint.deg2rad(offset[0]), katpoint.deg2rad(offset[1]), 
                                             antenna=ant_objects[0], timestamp=ts)
-                azel=[katpoint.wrap_angle(azel[0]), katpoint.wrap_angle(azel[1])]
+                azel = [katpoint.wrap_angle(azel[0]), katpoint.wrap_angle(azel[1])]
                 self.telstate.add(str(ant_objects[0].name)+'_pos_actual_scan_azim', azel[0], ts=ts)
                 self.telstate.add(str(ant_objects[0].name)+'_pos_actual_scan_elev', azel[1], ts=ts)
                 ts = ts + (self.dump_period/8)
@@ -979,7 +979,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         G = rs.uniform(2.0, 4.0, (2, self.n_antennas)) + 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas))
 
         # Making visibilities and preparing + sending heaps
-        vis=self.make_vis(K,G,target)
+        vis = self.make_vis(K,G,target)
         heaps = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis)
         for endpoint, heap in heaps:
             self.l0_streams[endpoint].send_heap(heap)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -760,6 +760,8 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
         cal_product_B_parts = telstate_cb_cal['product_B_parts']
         assert cal_product_B_parts == self.n_servers
+        cal_product_EPOINT_parts = telstate_cb_cal['product_EPOINT_parts']
+        assert cal_product_EPOINT_parts == self.n_servers
         ret_B, ret_B_ts = self.assemble_bandpass(telstate_cb_cal, 'product_B')
 
         cal_product_G = telstate_cb_cal.get_range('product_G', st=0)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -939,11 +939,8 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         for pointing in range(0,n_pointing):
             telstate_cb.add('obs_activity', 'track',
                             ts=self.first_dump_ts + (n_activity - 0.5) * self.dump_period)
-            print(telstate_cb['obs_activity'])
-            
             telstate_cb.add('obs_activity', 'slew',
                             ts=self.first_dump_ts + ((n_activity + 2) - 0.5) * self.dump_period)
-            print(telstate_cb['obs_activity'])
             n_activity+=3
 
         telstate_cb.add('obs_activity', 'await_pipeline',

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -1002,11 +1002,11 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         # Asserting dtypes, shape of cal product
         if 'pointingcal' in target.tags:
             for i in range(self.n_servers):
-                cal_product_EPOINTn = telstate_cb_cal.get_range('product_EPOINT'+'{}'.format(i), st=0)
+                cal_product_EPOINTn = telstate_cb_cal.get_range('product_EPOINT{}'.format(i), st=0)
                 assert len(cal_product_EPOINTn) == 1
-                EPOINTn = cal_product_EPOINTn[0]
-                assert EPOINTn.dtype == np.float32
-                assert EPOINTn.shape == (16 // self.n_servers, 2, self.n_antennas, 5)
+                ret_EPOINTn, ret_EPOINTn_ts = cal_product_EPOINTn[0]
+                assert ret_EPOINTn.dtype == np.float32
+                assert ret_EPOINTn.shape == (16 // self.n_servers, 2, self.n_antennas, 5)
 
     async def test_set_refant(self):
         """Tests the capture with a noisy antenna, and checks that the reference antenna is

--- a/katsdpcal/test/test_pipelineprocs.py
+++ b/katsdpcal/test/test_pipelineprocs.py
@@ -130,7 +130,7 @@ class TestParametersForBlankFreqWin(unittest.TestCase):
 
 class TestFinaliseParameters(unittest.TestCase):
     def setUp(self):
-        # These parameters are based on pipeline_parameters_meerkat_L.txt
+        # These parameters are based on pipeline_parameters_meerkat_L_wide.txt
         self.parameters = {
             'k_solint': 5.0,
             'k_chan_sample': 1,
@@ -154,7 +154,8 @@ class TestFinaliseParameters(unittest.TestCase):
                                  26.879, 32.611, 32.973, 66.216, 16.998, 0,  0,  0,  0],
             'bcross_sky_k': 3,
             'rfi_extend_hz': 391845,
-            'rfi_freq_chunks': 8
+            'rfi_freq_chunks': 8,
+            'epoint_freq_chunks': 16,
         }
 
         self.antennas = [
@@ -204,7 +205,7 @@ class TestFinaliseParameters(unittest.TestCase):
 
     def test_normal(self):
         parameters = pipelineprocs.finalise_parameters(
-            self.parameters, self.telstate_l0, 4, 2)
+            self.parameters, self.telstate_l0, servers=4, server_id=2)
         self.assertEqual(None, parameters['refant_index'])
         self.assertEqual(self.antenna_names, parameters['antenna_names'])
         self.assertEqual(self.antennas, parameters['antennas'])
@@ -218,6 +219,7 @@ class TestFinaliseParameters(unittest.TestCase):
         self.assertEqual(202, parameters['g_bchan'])
         self.assertEqual(402, parameters['g_echan'])
         self.assertEqual(2, parameters['rfi_freq_chunks'])
+        self.assertEqual(4, parameters['epoint_freq_chunks'])
         # bls_ordering, pol_ordering, bls_lookup get tested elsewhere
 
     def test_invalid_server_id(self):


### PR DESCRIPTION
The following changes integrate the new reference pointing functionality with the cal pipeline. 
 2 New functions added to reduction.py, the first get_offsets calculates the (x,y) offset co-ordinates
of each pointing offset, this is necessary because only the pos_actual_scan_azim/elev of the antennas 
 are known and can be found in telstate. Using katpoint.sphere to plane we can calculate the offset co-ordinates 
(in degrees) from their known azimuth and elevation, note only the reference antenna is used to do this.

The second function is flush_pipeline, which is essencially a secondary pipeline calibration,
when incoming data is pushed through the pipeline, once a 'pointingcal' tag is detected, the B solutions
will be calculated and once all of them are present in telstate, await pipeline event is triggered and 
B solutions will be passed to flush_pipeline where they are used along with other information such as
atmospheric conditions to calculate beam solutions from the fitting routines in katsdpcalproc.pointing:
get_offset_gains and beam_fit. Beam solutions are then saved (as an array of shape (num_chunks, len(pols), len(ants), 5)
where 5 corresponds to center, width and height of the beam) in telstate as a CalSolution product 
'product_EPOINT{N}' along with its uncertainties 'product_EPOINT_SNR{N}' which are needed to calculate
the offsets via calc_pointing_offsets on the CaptureSession side. Here N corresponds to the server/node number.

product_EPOINT and product_EPOINT_SNR were added to pipelineprocs.py parameters which allows us to save beam solutions to telstate under their correct product names. Similarly in control.py, CalSolutionStore 'B_POINTING' was added to 
existing solution stores which are passed into pipeline in reduction.py, this is the solution store in which
B solutions (gains) of the pointing observation will be stored. 

Finally, test_refrence_pointing_capturewas added to test_control, this tests that the mechanics of the reference pointing functionality works by  creating a target with a pointing cal tag then faking a track, track, slew for each of 8 pointing offsets
followed by an await_pipeline activity. This time, we have the offset (x,y) co-ordinates which we will use
to calculate the pos_actual_scan_azim/elev using katpoint.plane_to _sphere 4 times per dump. Antenna gains and
delays are created using random number generator and these are used to create visibilities. SPEAD heaps are then
created and sent. We then assert whether the expected cal products went into telstate as well as checking their
shape and dtypes. While this checks the mechanics of reference pointing, it does not however test the actual values 
of the solutions. This is something we should add in the future where gains are not random and have some frequency
dependence.