### PR TITLE
SPR1-3147: Phase up observation NMAD cal-report plots

### DIFF
--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -186,6 +186,8 @@ def _sum_corr(sum_corr, new_corr, limit=None):
         average of the current pipeline outputs and the previous outputs.
         For keys containing '_model', the output dictionary is a list containing the average of
         the current pipeline outputs and the previous outputs.
+        For keys containing '_nmad', the output dictionary is a list of the appended current
+        pipeline outputs and the previous outputs.
     """
     # list of keys which don't append data on a per scan basis
     keylist = ['t_flags']
@@ -214,6 +216,13 @@ def _sum_corr(sum_corr, new_corr, limit=None):
                 sum_corr[key] = [np.mean(sum_corr[key], 0)]
                 del new_corr[key]
                 keylist.append(key)
+
+            # append the nmad av_corr phase from each scan
+            elif key.endswith('_nmad'):
+               sum_corr[key] += new_corr[key]
+               del new_corr[key]
+               keylist.append(key)
+
 
             else:
                 sum_corr[key] += new_corr[key]

--- a/katsdpcal/control.py
+++ b/katsdpcal/control.py
@@ -219,10 +219,9 @@ def _sum_corr(sum_corr, new_corr, limit=None):
 
             # append the nmad av_corr phase from each scan
             elif key.endswith('_nmad'):
-               sum_corr[key] += new_corr[key]
-               del new_corr[key]
-               keylist.append(key)
-
+                sum_corr[key] += new_corr[key]
+                del new_corr[key]
+                keylist.append(key)
 
             else:
                 sum_corr[key] += new_corr[key]

--- a/katsdpcal/plotting.py
+++ b/katsdpcal/plotting.py
@@ -614,6 +614,7 @@ def plot_phase_stability_check(phase_nmad, correlator_freq, title=None,  pol=[0,
         axes[idx].set_xlabel('Frequency (Mhz)')
         axes[idx].legend(loc='upper right')
         axes[idx].grid(color='grey', which='both', lw=0.1)
+        axes[idx].set_ylim((0, np.nanstd(phase_nmad[:, p])*5))
 
     fig.tight_layout()
     fig.subplots_adjust(hspace=0.2)

--- a/katsdpcal/plotting.py
+++ b/katsdpcal/plotting.py
@@ -574,12 +574,15 @@ def plot_spec(data, chan, antenna_names=None, freq_range=None, title=None, amp=F
     fig.subplots_adjust(hspace=0.1)
     return fig
 
-def plot_phase_stability_check(phase_nmad, correlator_freq, title=None,  pol = [0, 1], y_scale = 0.5,  **plot_kwargs):
-    """Plot the Normalised Median Absolute Deviation of the Corrected Data Phases vs Frequency.
 
-    The plot will show that if the phase up of antennas was successful, 
+def plot_phase_stability_check(phase_nmad, correlator_freq, title=None,  pol=[0, 1], y_scale=0.5,
+                               **plot_kwargs):
+    """Plot the Normalised Median Absolute Deviation of the Corrected
+       Data Phases vs Frequency.
+
+    The plot will show that if the phase up of antennas was successful,
     the NMAD phase values will be similar accross frequency channels (RFI Free Regions)
-    and if the phase is unstable, antennas will show high deviations 
+    and if the phase is unstable, antennas will show high deviations
     from the median phase at that frequency. We plot the NMAD Phases for each polarisation
     this further provides information on the variation of phases for different pols.
 
@@ -594,27 +597,23 @@ def plot_phase_stability_check(phase_nmad, correlator_freq, title=None,  pol = [
     """
 
     npols = len(pol)
-    nchans = len(correlator_freq)
     nrows, ncols = npols, 1
-    rowsize = max(1, nchans / 1000.0)
-    fig, axes = plt.subplots(nrows=npols, ncols=ncols, figsize = (2 *  FIG_X, 2 * FIG_Y), 
-                squeeze=False, sharex = True)
+    fig, axes = plt.subplots(nrows=npols, ncols=ncols, figsize=(nrows * FIG_X, 2 * FIG_Y),
+                             sharex=True)
     axes = axes.flatten()
 
     if title is not None:
         fig.suptitle(title, y=1)
 
     for idx, p in enumerate(range(npols)):
-        #phase = phase[:, p]np.isnan
-            
 
-        axes[idx].plot(correlator_freq, phase_nmad[:, p], 
-                marker = '.', ls = 'dotted', ms='2',  
-                label=f'Average Phase NMAD :{np.nanmean(phase_nmad[:, p]): .3f}', **plot_kwargs)       
+        axes[idx].plot(correlator_freq, phase_nmad[:, p], marker='.', ls='',
+                       ms='2', label=f'Average Phase NMAD :{np.nanmean(phase_nmad[:, p]): .3f}',
+                       **plot_kwargs)
         axes[idx].set_ylabel('Phase NMAD_{0}'.format(pol[p]))
         axes[idx].set_xlabel('Frequency (Mhz)')
-        axes[idx].legend()
-        #axes[idx].grid(color='grey', which='both', lw=0.1)
+        axes[idx].legend(loc='upper right')
+        axes[idx].grid(color='grey', which='both', lw=0.1)
 
     fig.tight_layout()
     fig.subplots_adjust(hspace=0.2)

--- a/katsdpcal/plotting.py
+++ b/katsdpcal/plotting.py
@@ -574,6 +574,53 @@ def plot_spec(data, chan, antenna_names=None, freq_range=None, title=None, amp=F
     fig.subplots_adjust(hspace=0.1)
     return fig
 
+def plot_phase_stability_check(phase_nmad, correlator_freq, title=None,  pol = [0, 1], y_scale = 0.5,  **plot_kwargs):
+    """Plot the Normalised Median Absolute Deviation of the Corrected Data Phases vs Frequency.
+
+    The plot will show that if the phase up of antennas was successful, 
+    the NMAD phase values will be similar accross frequency channels (RFI Free Regions)
+    and if the phase is unstable, antennas will show high deviations 
+    from the median phase at that frequency. We plot the NMAD Phases for each polarisation
+    this further provides information on the variation of phases for different pols.
+
+    Parameters:
+    ----------
+    phase_nmad : :class: `np.ndarray`
+                 real, shape (freq, pol)
+    correlator_freq : :class: `np.ndarray`
+                       real, shape (freq, )
+    pol : list
+          list of polarisation desciptions
+    """
+
+    npols = len(pol)
+    nchans = len(correlator_freq)
+    nrows, ncols = npols, 1
+    rowsize = max(1, nchans / 1000.0)
+    fig, axes = plt.subplots(nrows=npols, ncols=ncols, figsize = (2 *  FIG_X, 2 * FIG_Y), 
+                squeeze=False, sharex = True)
+    axes = axes.flatten()
+
+    if title is not None:
+        fig.suptitle(title, y=1)
+
+    for idx, p in enumerate(range(npols)):
+        #phase = phase[:, p]np.isnan
+            
+
+        axes[idx].plot(correlator_freq, phase_nmad[:, p], 
+                marker = '.', ls = 'dotted', ms='2',  
+                label=f'Average Phase NMAD :{np.nanmean(phase_nmad[:, p]): .3f}', **plot_kwargs)       
+        axes[idx].set_ylabel('Phase NMAD_{0}'.format(pol[p]))
+        axes[idx].set_xlabel('Frequency (Mhz)')
+        axes[idx].legend()
+        #axes[idx].grid(color='grey', which='both', lw=0.1)
+
+    fig.tight_layout()
+    fig.subplots_adjust(hspace=0.2)
+
+    return fig
+
 
 def add_freq_axis(ax, chan_range, freq_range):
     """Adds a frequency axis to the top of a given matplotlib Axes.
@@ -583,7 +630,7 @@ def add_freq_axis(ax, chan_range, freq_range):
     ax : : class: `matplotlib.axes.Axes`
         Axes to add the frequency axis to
     chan_range : list
-        start and stop channel numbers
+         start and stop channel numbers
     freq_range : list
         start and stop frequencies corresponding to the start and stop channel numbers
     """

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -885,7 +885,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
             # summarize gain-calibrated targets
             gaintag = ['gaincal', 'target', 'bfcal']
             nogaintag = ['bpcal', 'delaycal']
-            phase_tag = ['bfcal', 'single_accumulation']
+            phase_tag = ['bfcal']
             if any(k in gaintag for k in taglist):
                 s.summarize_full(av_corr, target_name + '_g_spec', nchans=1024)
                 s.summarize(av_corr, target_name + '_g_bls')
@@ -897,6 +897,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 s.summarize(av_corr, target_name + '_nog_spec', nchans=1024, refant_only=True)
 
             # summarise phase_nmad
+            #add accumulate corrected scans, logic for incase needed
             # use the s.timestamps to map to the obs corrected 
             # and then use the s.timestamps corrected to mapp the corrected data dictionary
             # Or accumlate a list of corrected scanslices
@@ -917,7 +918,6 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 corrected_scans =  av_corr['timestamps'][mapping['corrected']]
 
                 return corrected_scans
-            #logger.info('averaged', av_corr.items())
 
             refant = parameters['refant']
             applied_gain_check = check_applied_gain_sensor(telstate = ts, ref_ant=refant, pol='h')
@@ -928,10 +928,7 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
 
                     # only av_corr scans in av_corr_corrected to be passed to this!
                     s.summarize_stats(av_corr, target_name + '_nmad_phase')
-
-            logger.info('Data Dict:', av_corr.keys())
-            logger.info('NMAD', av_corr[target_name+'_nmad_phase'])
-        return target_slices, av_corr
+    return target_slices, av_corr
 
 
 def get_offsets(ts, parameters, target, t_stamps, temp, pres, humi):

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -127,10 +127,9 @@ def check_applied_gain_sensor(telstate, ref_ant, pol):
        Open the pipeline `telstate` object via Katdal to create a visdatav4 datasource
        and extract the Applied Gain as a categorical data from Katdal Virtual Sensor store.
 
-       The Applied Gain sensor is calculated on the fly using 
-       the wide_antenna_channelised_voltage sensors for an antenna pol pair. 
-       In SPR1-3188 :  We investigate that for a phase up observation the number of
-       unique voltage values is 2 whilst for a delay cal observation
+       The Applied Gain sensor is calculated on the fly using the wide_antenna_channelised_voltage
+       sensors for an antenna pol pair. In SPR1-3188 :  We investigate that for a phase up
+       observation the number of unique voltage values is 2 whilst for a delay cal observation
        the number of unique voltage values is 1. We use this to set up a trigger condition
        to check if the observation is a phase-up.
 
@@ -138,11 +137,11 @@ def check_applied_gain_sensor(telstate, ref_ant, pol):
        -------
        telstate: :class: `katsdptelstate.TelescopeState`
                   Telescope State associated with the pipeline
-       ref_ant: :string  
+       ref_ant: :string
                  Name of reference antenna, ref_ant is appended to the `inp`
                  to create a sensor_name to access a reliable applied gain virtual sensor.
        pol: :string
-             Set a pol ['h', 'v'], a pol is appended to the `inp`. 
+            Set a pol ['h', 'v'], a pol is appended to the `inp`.
 
        Returns:
        --------
@@ -152,8 +151,8 @@ def check_applied_gain_sensor(telstate, ref_ant, pol):
 
     capture_block_id = telstate['capture_block_id']
     stream_name = telstate['stream_name']
-    telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate.root(), 
-            capture_block_id, stream_name)
+    telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate.root(),
+                                                                     capture_block_id, stream_name)
     source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None)
     data_source = VisibilityDataV4(source)
 
@@ -161,6 +160,7 @@ def check_applied_gain_sensor(telstate, ref_ant, pol):
     applied_gain_cat = data_source.sensor.get(sensor_name)
 
     return len(applied_gain_cat.unique_values)
+
 
 def get_solns_to_apply(s, solution_stores, sol_list, time_range=[], G_target=None):
     """Extract and interpolate specified cal solutions for a given scan.
@@ -897,37 +897,15 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                 s.summarize(av_corr, target_name + '_nog_spec', nchans=1024, refant_only=True)
 
             # summarise phase_nmad
-            #add accumulate corrected scans, logic for incase needed
-            # use the s.timestamps to map to the obs corrected 
-            # and then use the s.timestamps corrected to mapp the corrected data dictionary
-            # Or accumlate a list of corrected scanslices
-            # check if scan_slice.time is in a corrected data list (map obs label to the timestamps)
-
-            def acc_corrected_scans(ts, av_corr):
-                
-                capture_block_id = telstate['capture_block_id']
-                stream_name = telstate['stream_name']
-                telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate.root(),
-                capture_block_id, stream_name)
-                source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None)
-                data_source = VisibilityDataV4(source)
-                
-                mapping = defaultdict(list)
-                for scan, index in zip(data_source.sensor['obs_label'], data_source.dumps):
-                    mapping[scan].append(index)
-                corrected_scans =  av_corr['timestamps'][mapping['corrected']]
-
-                return corrected_scans
-
             refant = parameters['refant']
-            applied_gain_check = check_applied_gain_sensor(telstate = ts, ref_ant=refant, pol='h')
+            applied_gain_check = check_applied_gain_sensor(telstate=ts, ref_ant=refant, pol='h')
             if applied_gain_check > 1:
-                logger.info('Is Phase Up: Plotting NMAD Phases')
-                
+                logger.info('Is Phase Up: Calculate NMAD Phases')
+
                 if any(k in phase_tag for k in taglist):
 
-                    # only av_corr scans in av_corr_corrected to be passed to this!
                     s.summarize_stats(av_corr, target_name + '_nmad_phase')
+
     return target_slices, av_corr
 
 

--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -1102,10 +1102,8 @@ def write_products(report, report_path, ts, parameters,
         insert_fig(report_path, report, plot, name='No_{0}'.format(cal))
 
 
-
-
-def write_phase_stability(report, report_path, flux_cal, targets, av_corr, 
-        correlator_freq, is_calibrator=True, pol = [0, 1]):   
+def write_phase_stability(report, report_path, flux_cal, targets, av_corr,
+                          correlator_freq, is_calibrator=True, pol=[0, 1]):
 
     """
     Parameters
@@ -1128,33 +1126,33 @@ def write_phase_stability(report, report_path, flux_cal, targets, av_corr,
         description of polarisation axes, optional
 
     """
+    """
     if is_calibrator:
         suffix = (' and Phase', 'all gain-calibrated calibrators')
     else:
         suffix = ('', 'all target fields')
-
+    """
     if len(targets) > 0:
         report.write_heading_2('Corrected Scan NMAD Phase Stability')
         report.write_heading_3('Baseline Average NMAD')
-    
+
     for cal in targets:
         kat_target = katpoint.Target(cal)
         target_name = kat_target.name
         tags = [t for t in kat_target.tags if t in TAG_WHITELIST]
-       
-    # Add the plots for each time
-    av_data, av_times = list(zip(*av_corr['{}_nmad_phase'.format(target_name)]))
-    av_data = np.stack(av_data)
-    logger.info("av_data shape after stacking: %s", av_data.shape)
-    for ti in range(len(av_times)):
-        logger.info('ti % s', ti)
-        report.writeln()
-        t = utc_tstr(av_times[ti])
-        report.writeln('Time : {0}'.format(t))
-        plot_title = 'Calibrator {0}, tags are {1}'.format(target_name, ', '.join(tags))
-        plot = plotting.plot_phase_stability_check(av_data[ti], correlator_freq=correlator_freq, title=plot_title, pol=pol, y_scale=0.5)
-        insert_fig(report_path, report, plot, name=f'Phase_Stability_v_Freq')
-        report.writeln()
+        v_data, av_times = list(zip(*av_corr['{}_nmad_phase'.format(target_name)]))
+        av_data = np.array(v_data)
+        for ti in range(len(av_times)):
+            report.writeln()
+            t = utc_tstr(av_times[ti])
+            report.writeln('Time : {0}'.format(t))
+            phase_data = av_data[ti]
+            plot_title = 'Calibrator {0}, tags are {1}'.format(target_name, ', '.join(tags))
+            plot = plotting.plot_phase_stability_check(phase_data, correlator_freq=correlator_freq,
+                                                       title=plot_title, pol=pol, y_scale=0.5)
+            insert_fig(report_path, report, plot, name=f'Phase_Stability_v_Freq_{ti}')
+            report.writeln()
+
 
 def get_cal(ts, cal, ts_name, st, et):
     """Fetch a calibration product from telstate.
@@ -1734,7 +1732,6 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
 
                     # Corrected data : Calibrators
                     cal_rst.write_heading_1('Calibrator Summary Plots')
-
                     write_ng_freq(cal_rst, report_path, nogain, av_corr,
                                   refant_name, bls_names, correlator_freq, pol)
                     write_g_freq(cal_rst, report_path, flux_cal, gain, av_corr, antenna_names,
@@ -1745,8 +1742,7 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
                                antennas, cal_array_position, correlator_freq, True,
                                pol=pol)
                     write_phase_stability(cal_rst, report_path, flux_cal, gain, av_corr,
-                              correlator_freq, True, pol=pol) 
-                    # gain tag here has the bfcal (correlator gains)
+                                          correlator_freq, True, pol=pol)
 
                 # --------------------------------------------------------------------
                 # Corrected data : Targets
@@ -1755,7 +1751,6 @@ def make_cal_report(ts, capture_block_id, stream_name, parameters, report_path, 
                              cal_bls_lookup, correlator_freq, False, pol=pol)
                 write_g_uv(cal_rst, report_path, flux_cal, target, av_corr, cal_bls_lookup,
                            antennas, cal_array_position, correlator_freq, False, pol=pol)
-
 
             cal_rst.writeln()
 

--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -1133,8 +1133,8 @@ def write_phase_stability(report, report_path, flux_cal, targets, av_corr,
         suffix = ('', 'all target fields')
     """
     if len(targets) > 0:
-        report.write_heading_2('Corrected Scan NMAD Phase Stability')
-        report.write_heading_3('Baseline Average NMAD')
+        report.write_heading_2('Corrected Scan Phase Stability')
+        report.write_heading_3('Baseline Averaged Normalised Median Absolute Deviation (NMAD)')
 
     for cal in targets:
         kat_target = katpoint.Target(cal)

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -1291,7 +1291,7 @@ class Scan:
         av_corr[key].insert(0, val)
 
     def summarize_stats(self, av_corr, key, data=None, nchans=8):
-    
+
         """Summarize the Phases Normalised Median Absolute Deviation (NMAD).
 
         Average visibilities per scan, into nchans, frequency, pol, antenna.
@@ -1321,20 +1321,19 @@ class Scan:
             vis, flags, weights = data
 
         # average over time axis
-        av_vis, av_flags, av_weights = calprocs_dask.wavg_full(vis, flags, weights) 
-        av_vis, av_flags, av_weights = da.compute(av_vis, av_flags, av_weights) 
+        av_vis, av_flags, av_weights = calprocs_dask.wavg_full(vis, flags, weights)
+        av_vis, av_flags, av_weights = da.compute(av_vis, av_flags, av_weights)
         av_vis[av_flags] = np.nan
         phase_vis = np.angle(av_vis, deg=True)
-        logger.info('av_vis %s', av_vis.shape)
-        logger.info('phase shape %s', phase_vis.shape )
-
         # calculate the phase stability statistic
-        phase_nmad =  1.4826 * (np.nanmedian(np.abs(phase_vis - 
-                      np.nanmedian(phase_vis, axis=0)), axis=2)) 
-        logger.info('phase_nmad %s', phase_nmad.shape) # (freq, pol)
+        phase_nmad = 1.4826 * (np.nanmedian(np.abs(phase_vis -
+                               np.nanmedian(phase_vis, axis=0)), axis=2))
         val = (phase_nmad, np.average(self.timestamps))
-        av_corr[key].insert(0, val)
 
+        timestamp = int(np.average(self.timestamps))  # Convert to an integer for filename
+        filename = f"phase_nmad_{timestamp}.npy"
+        np.save(filename, phase_nmad)
+        av_corr[key].insert(0, val)
 
     # ----------------------------------------------------------------------
     # RFI Functions

--- a/katsdpcal/scan.py
+++ b/katsdpcal/scan.py
@@ -1290,6 +1290,52 @@ class Scan:
         val = (av_vis.compute(), np.average(self.timestamps))
         av_corr[key].insert(0, val)
 
+    def summarize_stats(self, av_corr, key, data=None, nchans=8):
+    
+        """Summarize the Phases Normalised Median Absolute Deviation (NMAD).
+
+        Average visibilities per scan, into nchans, frequency, pol, antenna.
+        Aggregate the normalised median deviation along the antenna axis.
+        The statistic is accumulated along the frequency dimension.
+        This provides a robust measure of dispersion for phase values.
+
+        Accumulate the  NMAD of the phases to a dictionary with given key.
+        Prefix the target_name to the dictionary key.
+
+        Parameters
+        ----------
+        av_corr : collections.defaultdict
+            dict to add averaged visibilities to
+        key : str
+            dictionary key
+        data : tuple of :class: `da.Array`, optional
+            vis, flags, weights of data to average. Defaults to
+            vis, flags and weights of self.cross_ant.tf.auto_pol
+        """
+
+        if not data:
+            vis = self.cross_ant.tf.auto_pol.vis
+            flags = self.cross_ant.tf.auto_pol.flags
+            weights = self.cross_ant.tf.auto_pol.weights
+        else:
+            vis, flags, weights = data
+
+        # average over time axis
+        av_vis, av_flags, av_weights = calprocs_dask.wavg_full(vis, flags, weights) 
+        av_vis, av_flags, av_weights = da.compute(av_vis, av_flags, av_weights) 
+        av_vis[av_flags] = np.nan
+        phase_vis = np.angle(av_vis, deg=True)
+        logger.info('av_vis %s', av_vis.shape)
+        logger.info('phase shape %s', phase_vis.shape )
+
+        # calculate the phase stability statistic
+        phase_nmad =  1.4826 * (np.nanmedian(np.abs(phase_vis - 
+                      np.nanmedian(phase_vis, axis=0)), axis=2)) 
+        logger.info('phase_nmad %s', phase_nmad.shape) # (freq, pol)
+        val = (phase_nmad, np.average(self.timestamps))
+        av_corr[key].insert(0, val)
+
+
     # ----------------------------------------------------------------------
     # RFI Functions
     @logsolutiontime

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -189,25 +189,24 @@ class SimData:
             raise ValueError('number of substreams must divide into the number of channels')
         parameter_dict['sdp_l0_n_chans_per_substream'] = n_chans // self.n_substreams
         # separate keys without times from those with times
-        obs_activity_key = 'obs_activity' 
-        target_activity_key =  'cbf_target'
+        obs_activity_key = 'obs_activity'
+        target_activity_key = 'cbf_target'
         obs_label_key = 'obs_label'
 
         notime_dict = {key: parameter_dict[key] for key in parameter_dict.keys()
                        if not key.endswith('noise_diode') and not key.endswith('_eq')
-                       and not obs_activity_key in key and not target_activity_key in key
-                       and not obs_label_key in key}
+                       and obs_activity_key not in key and target_activity_key not in key
+                       and obs_label_key not in key}
         time_dict = {key: parameter_dict[key] for key in parameter_dict.keys()
                      if key.endswith('noise_diode')}
-        volt_dict = {key: parameter_dict[key] for key in parameter_dict.keys() 
+        volt_dict = {key: parameter_dict[key] for key in parameter_dict.keys()
                      if key.endswith('_eq')}
-        targ_dict = {key: parameter_dict[key] for key in parameter_dict.keys() 
+        targ_dict = {key: parameter_dict[key] for key in parameter_dict.keys()
                      if target_activity_key in key}
-        obs_dict = {key: parameter_dict[key] for key in parameter_dict.keys() 
-                     if obs_activity_key in key}
+        obs_dict = {key: parameter_dict[key] for key in parameter_dict.keys()
+                    if obs_activity_key in key}
         obs_label_dict = {key: parameter_dict[key] for key in parameter_dict.keys()
-                     if obs_label_key in key}
-
+                          if obs_label_key in key}
 
         # add parameters to telescope state
         for key, value in sorted(notime_dict.items()):
@@ -219,13 +218,10 @@ class SimData:
             for v, t in value:
                 telstate.add(key, v, ts=t)
 
-
-
         for key, value in sorted(volt_dict.items()):
             logger.info('Setting %s', key)
             for v, t in value:
                 telstate.add(key, v, ts=t)
-
 
         for key, value in sorted(targ_dict.items()):
             logger.info('Setting %s', key)
@@ -236,7 +232,6 @@ class SimData:
             logger.info('Setting %s', key)
             for v, t in value:
                 telstate.add(key, v, ts=t)
-
 
         for key, value in sorted(obs_label_dict.items()):
             logger.info('Setting %s', key)
@@ -785,33 +780,34 @@ class SimDataKatdal(SimData):
             raise ValueError('Lower sideband is not supported')
         # spw will describe the whole band, ignoring bchan:echan. The caller
         # takes care of the adjustment.
-        param_dict['sdp_l0_bandwidth'] = spw.channel_width * spw.num_chans
-        param_dict['sdp_l0_center_freq'] = spw.centre_freq
-        param_dict['sdp_l0_n_chans'] = spw.num_chans
-        param_dict['sdp_l0_int_time'] = self.file.dump_period
-        param_dict['sdp_l0_bls_ordering'] = self.file.corr_products
-        param_dict['sdp_l0_sync_time'] = self.file.source.telstate['wide_sync_time']
-        param_dict['sub_band'] = self.file.spectral_windows[self.file.spw].band.lower()[0]
-        param_dict['sdp_l0_src_streams'] = self.file.source.telstate['sdp_l0_src_streams']
-        param_dict['sdp_l0_stream_type'] = self.file.source.telstate['sdp_l0_stream_type']
-        param_dict['chunk_info'] = self.file.source.telstate['chunk_info']
-        param_dict['first_timestamp'] = self.file.source.telstate['first_timestamp']
-        param_dict['sub_pool_resources'] = self.file.source.telstate['sub_pool_resources']
-        param_dict['sub_product'] = self.file.source.telstate['sub_product']
-        param_dict['obs_params'] = self.file.source.telstate['obs_params']
-        param_dict['obs_label'] = self.file.sensor['obs_label']
-        param_dict['stream_name'] = self.file.source.telstate['stream_name']
-        param_dict['capture_block_id'] = self.file.source.telstate['capture_block_id']
-        param_dict['wide_baseline_correlation_products_instrument_dev_name'] = self.file.source.telstate['wide_baseline_correlation_products_instrument_dev_name']
-        param_dict['wide_baseline_correlation_products_int_time'] = self.file.source.telstate['wide_baseline_correlation_products_int_time']
-        param_dict['wide_baseline_correlation_products_n_accs'] = self.file.source.telstate['wide_baseline_correlation_products_n_accs']
-        param_dict['wide_antenna_channelised_voltage_instrument_dev_name'] = self.file.source.telstate['wide_antenna_channelised_voltage_instrument_dev_name']
-        param_dict['wide_scale_factor_timestamp'] = self.file.source.telstate['wide_scale_factor_timestamp']
 
         # katsdpmodel keys
         telstate = self.file.source.telstate
         correlator_stream = telstate.view('sdp_l0')['src_streams'][0]
         f_engine_stream = telstate.view(correlator_stream)['src_streams'][0]
+        name = 'instrument_dev_name'
+        param_dict['sdp_l0_bandwidth'] = spw.channel_width * spw.num_chans
+        param_dict['sdp_l0_center_freq'] = spw.centre_freq
+        param_dict['sdp_l0_n_chans'] = spw.num_chans
+        param_dict['sdp_l0_int_time'] = self.file.dump_period
+        param_dict['sdp_l0_bls_ordering'] = self.file.corr_products
+        param_dict['sdp_l0_sync_time'] = telstate['wide_sync_time']
+        param_dict['sub_band'] = self.file.spectral_windows[self.file.spw].band.lower()[0]
+        param_dict['sdp_l0_src_streams'] = telstate['sdp_l0_src_streams']
+        param_dict['sdp_l0_stream_type'] = telstate['sdp_l0_stream_type']
+        param_dict['chunk_info'] = telstate['chunk_info']
+        param_dict['first_timestamp'] = telstate['first_timestamp']
+        param_dict['sub_pool_resources'] = telstate['sub_pool_resources']
+        param_dict['sub_product'] = telstate['sub_product']
+        param_dict['obs_params'] = telstate['obs_params']
+        param_dict['obs_label'] = self.file.sensor['obs_label']
+        param_dict['stream_name'] = telstate['stream_name']
+        param_dict['capture_block_id'] = telstate['capture_block_id']
+        param_dict[f'{correlator_stream}_{name}'] = telstate[f'{correlator_stream}_{name}']
+        param_dict[f'{correlator_stream}_int_time'] = telstate[f'{correlator_stream}_int_time']
+        param_dict[f'{correlator_stream}_n_accs'] = telstate[f'{correlator_stream}_n_accs']
+        param_dict[f'{f_engine_stream}_{name}'] = telstate[f'{f_engine_stream}_{name}']
+        param_dict['wide_scale_factor_timestamp'] = telstate['wide_scale_factor_timestamp']
 
         band_mask_key = telstate.join(f_engine_stream, 'model', 'band_mask', 'fixed')
         model_keys = [band_mask_key, 'sdp_model_base_url',
@@ -830,7 +826,6 @@ class SimDataKatdal(SimData):
             for pol in pol_list:
                 voltage_sensor = 'wide_antenna_channelised_voltage_{0}{1}_eq'.format(ant.name, pol)
                 param_dict[voltage_sensor] = telstate.get_range(voltage_sensor, st=0)
-
 
         target_activity_sensor = 'cbf_target'
         param_dict[target_activity_sensor] = telstate.get_range(target_activity_sensor, st=0)
@@ -861,7 +856,9 @@ class SimDataKatdal(SimData):
         flavour = spead2.Flavour(4, 64, 48)
         ig = spead2.send.ItemGroup(flavour=flavour)
 
-        self.setup_capture_block(telstate, (self.file.timestamps - self.file.source.telstate['sync_time'])[0]) # subtract sync_time to realign to the observation timing
+        # subtract sync_time to realign to the observation timing
+        sync_time = self.file.source.telstate['sync_time']
+        self.setup_capture_block(telstate, (self.file.timestamps - sync_time)[0])
         telstate_cb = telstate.view(self.cbid)
 
         # include obs params in telstate
@@ -898,7 +895,7 @@ class SimDataKatdal(SimData):
 
                 # data values to transmit
                 tx_time = self.file.timestamps[i]  # timestamp
-                logger.info('Timestamp %d', tx_time)
+                # logger.info('Timestamp %d', tx_time)
                 # visibilities for this time stamp, for specified channel range
                 tx_vis = scan_data[i, :, :]
                 # flags for this time stamp, for specified channel range

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -861,7 +861,7 @@ class SimDataKatdal(SimData):
         flavour = spead2.Flavour(4, 64, 48)
         ig = spead2.send.ItemGroup(flavour=flavour)
 
-        self.setup_capture_block(telstate, self.file.timestamps[0])
+        self.setup_capture_block(telstate, (self.file.timestamps - self.file.source.telstate['sync_time'])[0]) # subtract sync_time to realign to the observation timing
         telstate_cb = telstate.view(self.cbid)
 
         # include obs params in telstate
@@ -898,6 +898,7 @@ class SimDataKatdal(SimData):
 
                 # data values to transmit
                 tx_time = self.file.timestamps[i]  # timestamp
+                logger.info('Timestamp %d', tx_time)
                 # visibilities for this time stamp, for specified channel range
                 tx_vis = scan_data[i, :, :]
                 # flags for this time stamp, for specified channel range

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -1364,6 +1364,9 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         rs = np.random.RandomState(seed=1)
         with mock.patch.object(control.Pipeline, 'flush_pipeline', side_effect=ZeroDivisionError):
             await self.assert_sensor_value('pipeline-exceptions', 0)
+            target = ('J1331+3030_2, radec pointingcal, 13:31:08.29, +30:30:33.0, '
+                      '(0 50e3 0.1823 1.4757 -0.4739 0.0336)')
+            self.telstate.add('cbf_target', target, ts=0.003)
             for endpoint, heap in self.prepare_heaps(n_times=5, rs=rs):
                 self.l0_streams[endpoint].send_heap(heap)
             telstate_cb = self.telstate.view('cb')


### PR DESCRIPTION
This PR calculates the Normalised Median Absolute Deviation (NMAD) of the phases for the uncorrected and corrected track scanstates of a phase-up observation and thereafter plots the NMAD across frequency and adds these plots into the cal-report. In JIRA : [SPR1-3147 ](https://skaafrica.atlassian.net/browse/SPR1-3147) we have collected an investigation of NMAD metric as a statistic to determine phase stability at the 2 tracks of a phase up observation, and in the sub-tickets we have investigated the use of Katdal sensors to create a trigger condition for when these plots are to be added to the cal-report.
