### PR TITLE
SPR1-3225-fix-failing-cal-report-generation

### DIFF
--- a/katsdpcal/report.py
+++ b/katsdpcal/report.py
@@ -1132,7 +1132,10 @@ def write_phase_stability(report, report_path, targets, av_corr,
         kat_target = katpoint.Target(cal)
         target_name = kat_target.name
         tags = [t for t in kat_target.tags if t in TAG_WHITELIST]
-        v_data, av_times = list(zip(*av_corr['{}_nmad_phase'.format(target_name)]))
+        try:
+            v_data, av_times = list(zip(*av_corr['{}_nmad_phase'.format(target_name)]))
+        except ValueError:
+            continue
         av_data = np.array(v_data)
         for ti in range(len(av_times)):
             report.writeln()


### PR DESCRIPTION
The report generation failed for non-phase up observations (i.e for a delay cal observation). In this commit we add a try-except clause to check  whether  av_corr('nmad_phase') contains valid data for plotting, this is added to the `write_phase_stability` function in `report.py`.

Alternatively, we can try to make a more strict conditional statements in the `reduction.py`, currently the code in the pipeline checks if its phase up and checks for the corrected track and  if these are true is calculates the nmad_phases and passes this ito the summarize stats to store in the `av_corr` dictionary , for the non-phase up case it rightly does not calculate the nmad_phases but the nmad_phase tag is still created and this means the `av_corr('nmad_phase')` data is empty. If this dictionary is empty the report fails to generate, now with the try-except clause we added this will check this and continue the report making if the data is empty (i.e as in delay cal cases).

Having the try-except in the report is good, because this will check data validity and will continue/ skip to the next plot generations if invalid data is present (as in the case of non-phase ups). 

For delay cal observations there target tag has `bfcal`, when we populate the stats summarise we look for tags that contain `bfcal`, this could be why the `av_corr(nmad_phase)` is being made, should we make some stricter conditional in the reduction script such that for delay cals/ science observations the av_corr with key = nmad_phase should not be created (i.e av_corr('nmad_phase') dictionary key should not be  passed to the report for these cases). 


