### PR TITLE
SPR1-3215: Don't crash if antenna beams are missing (e.g. due to straggling)

### DIFF
--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -939,6 +939,10 @@ def _finish_pointing_cal(ts, parameters, b_solutions):
     beam_sol = np.full((num_chunks, len(pols), len(ants), 5), np.nan, dtype=np.float32)
     beam_sol_SNR = np.full((num_chunks, len(pols), len(ants), 5), np.nan, dtype=np.float32)
     for a, ant in enumerate(ants):
+        key = ant.name.strip()  # Ensure it's clean
+        if key not in beams:
+            logger.info(f"Skipping {key}, no beam available")
+            continue
         for c, beam in enumerate(beams[ant.name]):
             if beam is None:
                 continue

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -1000,7 +1000,8 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         G_nan = (rs.uniform(2.0, 4.0, (2, self.n_antennas)) +
                  1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
         # Inject a NaN into one antenna (e.g., m001, index 0) to simulate a missing beam
-        G_nan[:, 0] = np.nan  # or K_nan[:, 0]
+        G_nan[:, 0] = np.nan
+        K_nan[:, 0] = np.nan
         vis_nan = self.make_vis(K_nan, G_nan, target)
         heaps_nan = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis_nan)
         with patch("katsdpcal.reduction.logger") as mock_logger:

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -8,6 +8,7 @@ import shutil
 import os
 import itertools
 from unittest import mock, IsolatedAsyncioTestCase
+from unittest.mock import patch
 import asyncio
 import json
 import datetime
@@ -28,7 +29,7 @@ from katdal.h5datav3 import FLAG_NAMES
 from katdal.applycal import complex_interp
 from katsdpcalproc import calprocs
 
-from katsdpcal import control, pipelineprocs, param_dir
+from katsdpcal import control, pipelineprocs, param_dir, reduction
 
 
 numba.config.THREADING_LAYER = 'safe'
@@ -992,6 +993,29 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
         K = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
         G = (rs.uniform(2.0, 4.0, (2, self.n_antennas))
              + 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
+        
+        # --- Subtest: test for "missing antenna beam" exception ---
+        expected_message = "Skipping m001, no beam available"
+        K_nan = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
+        G_nan = (rs.uniform(2.0, 4.0, (2, self.n_antennas)) +
+                 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
+        # Inject a NaN into one antenna (e.g., m001, index 0) to simulate a missing beam
+        G_nan[:, 0] = np.nan  # or K_nan[:, 0]
+        vis_nan = self.make_vis(K_nan, G_nan, target)
+        heaps_nan = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis_nan)
+        with patch("katsdpcal.reduction.logger") as mock_logger:
+            for endpoint, heap in heaps_nan:
+                self.l0_streams[endpoint].send_heap(heap)
+            await self.make_request("capture-init", "cb")
+            await asyncio.sleep(1)
+            for stream in self.l0_streams.values():
+                stream.send_heap(self.ig.get_end())
+            await self.shutdown_servers(180)
+            matching_calls = [
+                call for call in mock_logger.info.call_args_list
+                if call.args and expected_message in call.args[0]
+            ]
+            assert len(matching_calls) == self.n_server
 
         # Making visibilities and preparing + sending heaps
         vis = self.make_vis(K, G, target)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -28,8 +28,7 @@ import katpoint
 from katdal.h5datav3 import FLAG_NAMES
 from katdal.applycal import complex_interp
 from katsdpcalproc import calprocs
-
-from katsdpcal import control, pipelineprocs, param_dir, reduction
+from katsdpcal import control, pipelineprocs, param_dir
 
 
 numba.config.THREADING_LAYER = 'safe'
@@ -995,8 +994,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                  1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
         # Inject a NaN into one antenna (e.g., m090, index 0) to simulate a missing beam
         G_nan[:, 0] = np.nan
-        K_nan[:, 0] = np.nan
-        
+        K_nan[:, 0] = np.nan       
         # Making visibilities and preparing + sending heaps
         vis = self.make_vis(K_nan, G_nan, target)
         with patch("katsdpcal.reduction.logger") as mock_logger:
@@ -1005,7 +1003,6 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                 self.l0_streams[endpoint].send_heap(heap)
             await self.make_request('capture-init', 'cb')
             await asyncio.sleep(1)
-    
             for stream in self.l0_streams.values():
                 stream.send_heap(self.ig.get_end())
             await self.shutdown_servers(180)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -995,11 +995,11 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
              + 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
         
         # --- Subtest: test for "missing antenna beam" exception ---
-        expected_message = "Skipping m001, no beam available"
+        expected_message = "Skipping m090, no beam available"
         K_nan = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
         G_nan = (rs.uniform(2.0, 4.0, (2, self.n_antennas)) +
                  1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
-        # Inject a NaN into one antenna (e.g., m001, index 0) to simulate a missing beam
+        # Inject a NaN into one antenna (e.g., m090, index 0) to simulate a missing beam
         G_nan[:, 0] = np.nan
         K_nan[:, 0] = np.nan
         vis_nan = self.make_vis(K_nan, G_nan, target)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -989,14 +989,14 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                     ts = ts + (self.dump_period/8)
 
         # Creating antenna delays and gains
-        K_nan = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
-        G_nan = (rs.uniform(2.0, 4.0, (2, self.n_antennas)) +
-                 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
+        K = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
+        G = (rs.uniform(2.0, 4.0, (2, self.n_antennas))
+             + 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
         # Inject a NaN into one antenna (e.g., m090, index 0) to simulate a missing beam
-        G_nan[:, 0] = np.nan
-        K_nan[:, 0] = np.nan
+        G[:, 0] = np.nan
+        K[:, 0] = np.nan
         # Making visibilities and preparing + sending heaps
-        vis = self.make_vis(K_nan, G_nan, target)
+        vis = self.make_vis(K, G, target)
         with patch("katsdpcal.reduction.logger") as mock_logger:
             heaps = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis)
             for endpoint, heap in heaps:

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -1015,7 +1015,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                 call for call in mock_logger.info.call_args_list
                 if call.args and expected_message in call.args[0]
             ]
-            assert len(matching_calls) == self.n_server
+            assert len(matching_calls) == self.n_servers
 
         # Making visibilities and preparing + sending heaps
         vis = self.make_vis(K, G, target)

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -994,7 +994,7 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                  1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
         # Inject a NaN into one antenna (e.g., m090, index 0) to simulate a missing beam
         G_nan[:, 0] = np.nan
-        K_nan[:, 0] = np.nan       
+        K_nan[:, 0] = np.nan
         # Making visibilities and preparing + sending heaps
         vis = self.make_vis(K_nan, G_nan, target)
         with patch("katsdpcal.reduction.logger") as mock_logger:

--- a/katsdpcal/test/test_control.py
+++ b/katsdpcal/test/test_control.py
@@ -990,46 +990,31 @@ class TestCalDeviceServer(IsolatedAsyncioTestCase):
                     ts = ts + (self.dump_period/8)
 
         # Creating antenna delays and gains
-        K = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
-        G = (rs.uniform(2.0, 4.0, (2, self.n_antennas))
-             + 1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
-        
-        # --- Subtest: test for "missing antenna beam" exception ---
-        expected_message = "Skipping m090, no beam available"
         K_nan = rs.uniform(-50e-12, 50e-12, (2, self.n_antennas))
         G_nan = (rs.uniform(2.0, 4.0, (2, self.n_antennas)) +
                  1j * rs.uniform(-0.1, 0.1, (2, self.n_antennas)))
         # Inject a NaN into one antenna (e.g., m090, index 0) to simulate a missing beam
         G_nan[:, 0] = np.nan
         K_nan[:, 0] = np.nan
-        vis_nan = self.make_vis(K_nan, G_nan, target)
-        heaps_nan = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis_nan)
+        
+        # Making visibilities and preparing + sending heaps
+        vis = self.make_vis(K_nan, G_nan, target)
         with patch("katsdpcal.reduction.logger") as mock_logger:
-            for endpoint, heap in heaps_nan:
+            heaps = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis)
+            for endpoint, heap in heaps:
                 self.l0_streams[endpoint].send_heap(heap)
-            await self.make_request("capture-init", "cb")
+            await self.make_request('capture-init', 'cb')
             await asyncio.sleep(1)
+    
             for stream in self.l0_streams.values():
                 stream.send_heap(self.ig.get_end())
             await self.shutdown_servers(180)
+            expected_message = "Skipping m090, no beam available"
             matching_calls = [
                 call for call in mock_logger.info.call_args_list
                 if call.args and expected_message in call.args[0]
             ]
             assert len(matching_calls) == self.n_servers
-
-        # Making visibilities and preparing + sending heaps
-        vis = self.make_vis(K, G, target)
-        heaps = self.prepare_heaps(n_times=n_times, rs=rs, vis=vis)
-        for endpoint, heap in heaps:
-            self.l0_streams[endpoint].send_heap(heap)
-        await self.make_request('capture-init', 'cb')
-        await asyncio.sleep(1)
-
-        for stream in self.l0_streams.values():
-            stream.send_heap(self.ig.get_end())
-        await self.shutdown_servers(180)
-
         telstate_cb_cal = control.make_telstate_cb(self.telstate_cal, 'cb')
         # Asserting dtypes, shape of cal product
         if 'pointingcal' in target.tags:


### PR DESCRIPTION
These changes are aimed to fix and test for the missing beam bug. In reference pointing, if there is a straggling antenna the pipeline crashes because no beam solutions are found for that antenna. This should not happen, in the case of a missing beam solution, it should be logged and skipped over, not crash. 
In _finish_pointing_cal in reduction.py, I have added an if statement so that in the case where an antenna key is not found in the beams, it logs a message and continues onto the next antenna.
In order to test this, I have added a subtest to test_control.py which simulates a missing beam solution by inserting Nan values into the gains for one of the antennas axis (m001) and then patching the logger from reduction.py using unnittest,patch. Then asserting that the number of calls with the message 'Skipping m001, no beam available' in the logs is equivalent to the number of servers used.