### PR TITLE
SPR1-3249-fix_check_applied_gain

### DIFF
--- a/katsdpcal/plotting.py
+++ b/katsdpcal/plotting.py
@@ -611,14 +611,15 @@ def plot_phase_stability_check(phase_nmad, correlator_freq, title=None,  pol=[0,
                        ms='2', label=f'Average Phase NMAD :{np.nanmean(phase_nmad[:, p]): .3f}',
                        **plot_kwargs)
         axes[idx].set_ylabel('Phase NMAD_{0}'.format(pol[p]))
-        axes[idx].set_xlabel('Frequency (Mhz)')
         axes[idx].legend(bbox_to_anchor=(1.0, 1.0), loc="upper left", frameon=False)
         axes[idx].grid(color='grey', which='both', lw=0.1)
-        axes[idx].set_ylim((0, np.nanstd(phase_nmad[:, p])*5))
+        axes[idx].set_ylim((0, np.nanmean(phase_nmad[:, p]) + 5 * np.nanstd(phase_nmad[:, p])))
+
+    l_p = npols - 1
+    axes[l_p].set_xlabel('Frequency (MHz)')
 
     fig.tight_layout()
     fig.subplots_adjust(hspace=0.2)
-
     return fig
 
 

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -135,7 +135,9 @@ def check_is_corrected(telstate, time_range):
     bool:
         True for track that has a 'corrected' label in the `time_range`
     """
-    capture_block_id = telstate.get_range('sdp_capture_block_id')[0][0]
+    capture_block_id = telstate.get_range('sdp_capture_block_id',
+                                          st=time_range[0], et=time_range[1],
+                                          include_previous=True)[0][0]
     obs_label_key = '{}_obs_label'.format(capture_block_id)
     obs_label = telstate.get_range(obs_label_key, st=time_range[0], et=time_range[1],
                                    include_previous=True)
@@ -146,7 +148,7 @@ def check_is_corrected(telstate, time_range):
         return False
 
 
-def check_applied_gain_sensor(telstate, ref_ant, pol):
+def check_applied_gain_sensor(s, telstate, ref_ant, pol, time_range):
 
     """Trigger Function : Check the number of unique values in the Applied Gain Sensor.
 
@@ -175,11 +177,15 @@ def check_applied_gain_sensor(telstate, ref_ant, pol):
         Number of unique elements found in the applied gain sensor for the observation
        """
 
-    capture_block_id = telstate.get_range('sdp_capture_block_id')[0][0]
+    capture_block_id = telstate.get_range('sdp_capture_block_id',
+                                          st=time_range[0], et=time_range[1],
+                                          include_previous=True)[0][0]
     stream_name = telstate['cal_src_streams'][0]
     telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate.root(),
                                                                      capture_block_id, stream_name)
-    source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None)
+    timestamps = s.timestamps
+    source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None,
+                                timestamps=timestamps)
     data_source = VisibilityDataV4(source)
 
     sensor_name = f'Correlator/Inputs/{ref_ant}{pol}/applied_gain'
@@ -886,14 +892,19 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
             phase_tag = ['bfcal']
             # summarise phase_nmad
             refant = parameters['refant']
-            if any(k in phase_tag for k in taglist):
-                applied_gain_check = check_applied_gain_sensor(telstate=ts, ref_ant=refant, pol='h')
-                corrected_track = check_is_corrected(ts, [t0, t1])
-                if applied_gain_check > 1:
-                    logger.info('Observation is Phase-Up')
-                    if corrected_track:
-                        logger.info('Calculate NMAD on Corrected Track')
-                        s.summarize_stats(av_corr, target_name + '_nmad_phase')
+            try:
+                if any(k in phase_tag for k in taglist):
+                    applied_gain_check = check_applied_gain_sensor(s, telstate=ts,
+                                                                   ref_ant=refant, pol='h',
+                                                                   time_range=[t0, t1])
+                    corrected_track = check_is_corrected(ts, [t0, t1])
+                    if applied_gain_check > 1:
+                        logger.info('Observation is Phase-Up')
+                        if corrected_track:
+                            logger.info('Calculate NMAD on Corrected Track')
+                            s.summarize_stats(av_corr, target_name + '_nmad_phase')
+            except Exception:
+                pass
 
             s.apply_inplace(solns_to_apply)
 

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -185,9 +185,7 @@ def check_applied_gain_sensor(s, telstate, ref_ant, pol, time_range):
                                                                      capture_block_id, stream_name)
     t0 = telstate['sync_time'] + telstate['first_timestamp']
     int_time = telstate['int_time']
-    chunk_info = telstate[f'{capture_block_id}_sdp_l0_chunk_info']
-    n_dumps = chunk_info['correlator_data']['shape'][0]
-    timestamps = t0 + np.arange(n_dumps) * int_time
+    timestamps = np.arange(t0, time_range[1], int_time)
     source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None,
                                 timestamps=timestamps)
     data_source = VisibilityDataV4(source)

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -183,7 +183,11 @@ def check_applied_gain_sensor(s, telstate, ref_ant, pol, time_range):
     stream_name = telstate['cal_src_streams'][0]
     telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate.root(),
                                                                      capture_block_id, stream_name)
-    timestamps = s.timestamps
+    t0 = telstate['sync_time'] + telstate['first_timestamp']
+    int_time = telstate['int_time']
+    chunk_info = telstate['chunk_info']
+    n_dumps = chunk_info['correlator_data']['shape'][0]
+    timestamps = t0 + np.arange(n_dumps) * int_time
     source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None,
                                 timestamps=timestamps)
     data_source = VisibilityDataV4(source)
@@ -903,8 +907,8 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
                         if corrected_track:
                             logger.info('Calculate NMAD on Corrected Track')
                             s.summarize_stats(av_corr, target_name + '_nmad_phase')
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning(f"Failed to check applied gain: {e}")
 
             s.apply_inplace(solns_to_apply)
 

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -185,7 +185,7 @@ def check_applied_gain_sensor(s, telstate, ref_ant, pol, time_range):
                                                                      capture_block_id, stream_name)
     t0 = telstate['sync_time'] + telstate['first_timestamp']
     int_time = telstate['int_time']
-    chunk_info = telstate['chunk_info']
+    chunk_info = telstate[f'{capture_block_id}_sdp_l0_chunk_info']
     n_dumps = chunk_info['correlator_data']['shape'][0]
     timestamps = t0 + np.arange(n_dumps) * int_time
     source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None,

--- a/katsdpcal/reduction.py
+++ b/katsdpcal/reduction.py
@@ -135,7 +135,9 @@ def check_is_corrected(telstate, time_range):
     bool:
         True for track that has a 'corrected' label in the `time_range`
     """
-    obs_label = telstate.get_range('obs_label', st=time_range[0], et=time_range[1],
+    capture_block_id = telstate.get_range('sdp_capture_block_id')[0][0]
+    obs_label_key = '{}_obs_label'.format(capture_block_id)
+    obs_label = telstate.get_range(obs_label_key, st=time_range[0], et=time_range[1],
                                    include_previous=True)
     values, times = zip(*obs_label)
     if 'corrected' in values:
@@ -173,8 +175,8 @@ def check_applied_gain_sensor(telstate, ref_ant, pol):
         Number of unique elements found in the applied gain sensor for the observation
        """
 
-    capture_block_id = telstate['capture_block_id']
-    stream_name = telstate['stream_name']
+    capture_block_id = telstate.get_range('sdp_capture_block_id')[0][0]
+    stream_name = telstate['cal_src_streams'][0]
     telstate, capture_block_id, stream_name = view_l0_capture_stream(telstate.root(),
                                                                      capture_block_id, stream_name)
     source = TelstateDataSource(telstate, capture_block_id, stream_name, chunk_store=None)
@@ -884,13 +886,13 @@ def pipeline(data, ts, parameters, solution_stores, stream_name, sensors=None):
             phase_tag = ['bfcal']
             # summarise phase_nmad
             refant = parameters['refant']
-            applied_gain_check = check_applied_gain_sensor(telstate=ts, ref_ant=refant, pol='h')
-            corrected_track = check_is_corrected(ts, [t0, t1])
-            if applied_gain_check > 1:
-                logger.info('Observation is Phase-Up')
-                if corrected_track:
-                    logger.info('Calculate NMAD on Corrected Track')
-                    if any(k in phase_tag for k in taglist):
+            if any(k in phase_tag for k in taglist):
+                applied_gain_check = check_applied_gain_sensor(telstate=ts, ref_ant=refant, pol='h')
+                corrected_track = check_is_corrected(ts, [t0, t1])
+                if applied_gain_check > 1:
+                    logger.info('Observation is Phase-Up')
+                    if corrected_track:
+                        logger.info('Calculate NMAD on Corrected Track')
                         s.summarize_stats(av_corr, target_name + '_nmad_phase')
 
             s.apply_inplace(solns_to_apply)

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -120,7 +120,7 @@ class SimData:
                                'obs_params', f'{correlator_stream}_{ins_name}',
                                f'{correlator_stream}_int_time', f'{correlator_stream}_n_accs',
                                f'{f_engine_stream}_{ins_name}', 'wide_scale_factor_timestamp',
-                               'wide_sync_time', 'chunk_info', 'cal_src_streams']
+                               'wide_sync_time', 'cal_src_streams']
 
         for key in telstate_immutables:
             param_dict[key] = telstate[key]
@@ -345,7 +345,7 @@ class SimData:
         if n_chans % self.n_substreams != 0:
             raise ValueError('number of substreams must divide into the number of channels')
         parameter_dict['sdp_l0_n_chans_per_substream'] = n_chans // self.n_substreams
-        CBID = parameter_dict['sdp_capture_block_id'][1][0]
+        CBID = parameter_dict['sdp_capture_block_id'][-1][0]
 
         # separate keys without times from those with times
         sensor_key_suffixes = ('obs_activity', '_eq', 'cbf_target', 'target_activity',

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -125,7 +125,8 @@ class SimData:
         for key in telstate_immutables:
             param_dict[key] = telstate[key]
 
-        telstate_mutables = ['cbf_target', 'obs_label', 'obs_activity']
+        telstate_mutables = ['cbf_target', 'obs_label', 'obs_activity', 'sdp_capture_block_id',
+                             f"{telstate['capture_block_id']}_obs_label"]
         for key in telstate_mutables:
             param_dict[key] = telstate.get_range(key, st=0)
 
@@ -344,10 +345,11 @@ class SimData:
         if n_chans % self.n_substreams != 0:
             raise ValueError('number of substreams must divide into the number of channels')
         parameter_dict['sdp_l0_n_chans_per_substream'] = n_chans // self.n_substreams
+        CBID = parameter_dict['capture_block_id']
 
         # separate keys without times from those with times
         sensor_key_suffixes = ('obs_activity', '_eq', 'cbf_target', 'target_activity', 'obs_label',
-                               'noise_diode')
+                               'noise_diode', 'sdp_capture_block_id',  f"{CBID}_obs_label")
         sensor_keys = [k for k in parameter_dict.keys() if k.endswith(sensor_key_suffixes)]
 
         for k in parameter_dict.keys():

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -116,17 +116,17 @@ class SimData:
         param_dict['sub_band'] = self.file.spectral_windows[self.file.spw].band.lower()[0]
 
         telstate_immutables = ['sdp_l0_sync_time', 'sdp_l0_src_streams', 'sdp_l0_stream_type',
-                               'chunk_info', 'first_timestamp', 'sub_pool_resources', 'sub_product',
-                               'obs_params', 'stream_name', 'capture_block_id',
-                               f'{correlator_stream}_{ins_name}', f'{correlator_stream}_int_time',
-                               f'{correlator_stream}_n_accs', f'{f_engine_stream}_{ins_name}',
-                               'wide_scale_factor_timestamp', 'wide_sync_time']
+                               'sdp_l0_first_timestamp', 'sub_pool_resources', 'sub_product',
+                               'obs_params', f'{correlator_stream}_{ins_name}',
+                               f'{correlator_stream}_int_time', f'{correlator_stream}_n_accs',
+                               f'{f_engine_stream}_{ins_name}', 'wide_scale_factor_timestamp',
+                               'wide_sync_time', 'chunk_info', 'cal_src_streams']
 
         for key in telstate_immutables:
             param_dict[key] = telstate[key]
 
-        telstate_mutables = ['cbf_target', 'obs_label', 'obs_activity', 'sdp_capture_block_id',
-                             f"{telstate['capture_block_id']}_obs_label"]
+        telstate_mutables = ['cbf_target', 'obs_activity', 'sdp_capture_block_id',
+                             f"{telstate.get_range('sdp_capture_block_id', st=0)[-1][0]}_obs_label"]
         for key in telstate_mutables:
             param_dict[key] = telstate.get_range(key, st=0)
 
@@ -345,10 +345,10 @@ class SimData:
         if n_chans % self.n_substreams != 0:
             raise ValueError('number of substreams must divide into the number of channels')
         parameter_dict['sdp_l0_n_chans_per_substream'] = n_chans // self.n_substreams
-        CBID = parameter_dict['capture_block_id']
+        CBID = parameter_dict['sdp_capture_block_id'][1][0]
 
         # separate keys without times from those with times
-        sensor_key_suffixes = ('obs_activity', '_eq', 'cbf_target', 'target_activity', 'obs_label',
+        sensor_key_suffixes = ('obs_activity', '_eq', 'cbf_target', 'target_activity',
                                'noise_diode', 'sdp_capture_block_id',  f"{CBID}_obs_label")
         sensor_keys = [k for k in parameter_dict.keys() if k.endswith(sensor_key_suffixes)]
 


### PR DESCRIPTION
In this commit we address the failing nmad phase plot generation due to sensor keys that are not available in the live telstate of an observation. We use aliases of `stream_name` `obs_label`  and `capture_block_id` to be used by `check_applied_gain` to make the required katdal object for us to get the applied gain values to check if the observation is phase up to trigger the pipeline to make nmad phase plots.

We also address the issue of the pipeline triggering nmad phase generation for image observations, this should not happen. Here we move the `bfcal` check as the first check, to flag and pass only observations that have the `bfcal` tag to the next applied gain check.