### PR TITLE
SPP1-178: skip band mask fetch for narrowband cbfplus-proxy observations

### DIFF
--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -256,6 +256,30 @@ def _get_rfi_mask(telstate_l0):
 
 
 def _get_band_mask(telstate_l0):
+    """
+    Get band mask model, but skip for narrowband with cbfplus-proxy API.
+
+    For narrowband observations (≤ 107.0 MHz) using the cbfplus-proxy API,
+    the band mask is skipped. For wideband observations or narrowband with other APIs,
+    the standard band edge fetching is performed.
+    """
+    # Check if this is a narrowband observation with 'data-cbfplus-proxy'(MeerKAT+ correlator) API
+    try:
+        bandwidth = telstate_l0.get('sdp_l0_bandwidth')
+        bandwidth_mhz = (bandwidth * u.Hz).to(u.MHz).value
+        cbf_api_version = telstate_l0.get('cbf_api_version', '')
+        # Skip band mask only for narrowband + cbfplus-proxy combination
+        if bandwidth_mhz <= 107.0 and isinstance(cbf_api_version, str) \
+                and cbf_api_version.startswith('data-cbfplus-proxy'):
+            logger.info('Skipping band mask for narrowband (%.1f MHz) with cbfplus-proxy API: %s',
+                        bandwidth_mhz, cbf_api_version)
+            return None
+    except (KeyError, AttributeError) as exc:
+        logger.warning('Could not get cbf_api_version, proceeding with band mask fetch: %s', exc)
+
+    # Normal band mask fetching for:
+    # - Wide-band observations
+    # - Narrow-band observations with the non-MeerKAT-plus correlator
     with katsdpmodels.fetch.requests.TelescopeStateFetcher(telstate_l0) as fetcher:
         correlator_stream = telstate_l0['src_streams'][0]
         f_engine_stream = telstate_l0.view(correlator_stream, exclusive=True)['src_streams'][0]

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -262,19 +262,12 @@ def cbf_flavour(telstate_l0):
 
 
 def _get_band_mask(telstate_l0):
-    """
-    Get band mask model, but skip for narrowband with cbfplus-proxy API.
-
-    For narrowband observations (≤ 107.0 MHz) using the cbfplus-proxy API,
-    the band mask is skipped. For wideband observations or narrowband with other APIs,
-    the standard band edge fetching is performed.
-    """
     # Check if this is a narrowband observation with 'data-cbfplus-proxy' (MeerKAT+ correlator) API
-    bandwidth = telstate_l0['bandwidth']* u.Hz
+    bandwidth = telstate_l0['bandwidth'] * u.Hz
     if bandwidth <= 107.0 * u.MHz and cbf_flavour(telstate_l0) == 'MK+':
         logger.info('Skipping band mask for narrowband (%.1f) with MK+ correlator', bandwidth)
         return None
-        
+
     # Normal band mask fetching for:
     # - Wide-band observations
     # - Narrow-band observations with the non-MeerKAT-plus correlator

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -255,6 +255,12 @@ def _get_rfi_mask(telstate_l0):
             return None
 
 
+def cbf_flavour(telstate_l0):
+    """Return the CBF flavour ('MK+' or 'MK') based on telstate cbf_api_version."""
+    api_version = telstate_l0['cbf_api_version']
+    return 'MK+' if api_version.startswith('data-cbfplus-proxy') else 'MK'
+
+
 def _get_band_mask(telstate_l0):
     """
     Get band mask model, but skip for narrowband with cbfplus-proxy API.
@@ -263,16 +269,13 @@ def _get_band_mask(telstate_l0):
     the band mask is skipped. For wideband observations or narrowband with other APIs,
     the standard band edge fetching is performed.
     """
-    # Check if this is a narrowband observation with 'data-cbfplus-proxy'(MeerKAT+ correlator) API
+    # Check if this is a narrowband observation with 'data-cbfplus-proxy' (MeerKAT+ correlator) API
     try:
-        bandwidth = telstate_l0.get('sdp_l0_bandwidth')
+        bandwidth = telstate_l0['sdp_l0_bandwidth']
         bandwidth_mhz = (bandwidth * u.Hz).to(u.MHz).value
-        cbf_api_version = telstate_l0.get('cbf_api_version', '')
-        # Skip band mask only for narrowband + cbfplus-proxy combination
-        if bandwidth_mhz <= 107.0 and isinstance(cbf_api_version, str) \
-                and cbf_api_version.startswith('data-cbfplus-proxy'):
-            logger.info('Skipping band mask for narrowband (%.1f MHz) with cbfplus-proxy API: %s',
-                        bandwidth_mhz, cbf_api_version)
+        if bandwidth_mhz <= 107.0 and cbf_flavour(telstate_l0) == 'MK+':
+            logger.info('Skipping band mask for narrowband (%.1f MHz) with MK+ correlator',
+                        bandwidth_mhz)
             return None
     except (KeyError, AttributeError) as exc:
         logger.warning('Could not get cbf_api_version, proceeding with band mask fetch: %s', exc)

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -271,7 +271,7 @@ def _get_band_mask(telstate_l0):
     """
     # Check if this is a narrowband observation with 'data-cbfplus-proxy' (MeerKAT+ correlator) API
     try:
-        bandwidth = telstate_l0['sdp_l0_bandwidth']
+        bandwidth = telstate_l0['bandwidth']
         bandwidth_mhz = (bandwidth * u.Hz).to(u.MHz).value
         if bandwidth_mhz <= 107.0 and cbf_flavour(telstate_l0) == 'MK+':
             logger.info('Skipping band mask for narrowband (%.1f MHz) with MK+ correlator',

--- a/katsdpcal/pipelineprocs.py
+++ b/katsdpcal/pipelineprocs.py
@@ -257,7 +257,7 @@ def _get_rfi_mask(telstate_l0):
 
 def cbf_flavour(telstate_l0):
     """Return the CBF flavour ('MK+' or 'MK') based on telstate cbf_api_version."""
-    api_version = telstate_l0['cbf_api_version']
+    api_version = telstate_l0.get('cbf_api_version', 'data-cbf-proxy-0.1')
     return 'MK+' if api_version.startswith('data-cbfplus-proxy') else 'MK'
 
 
@@ -270,16 +270,11 @@ def _get_band_mask(telstate_l0):
     the standard band edge fetching is performed.
     """
     # Check if this is a narrowband observation with 'data-cbfplus-proxy' (MeerKAT+ correlator) API
-    try:
-        bandwidth = telstate_l0['bandwidth']
-        bandwidth_mhz = (bandwidth * u.Hz).to(u.MHz).value
-        if bandwidth_mhz <= 107.0 and cbf_flavour(telstate_l0) == 'MK+':
-            logger.info('Skipping band mask for narrowband (%.1f MHz) with MK+ correlator',
-                        bandwidth_mhz)
-            return None
-    except (KeyError, AttributeError) as exc:
-        logger.warning('Could not get cbf_api_version, proceeding with band mask fetch: %s', exc)
-
+    bandwidth = telstate_l0['bandwidth']* u.Hz
+    if bandwidth <= 107.0 * u.MHz and cbf_flavour(telstate_l0) == 'MK+':
+        logger.info('Skipping band mask for narrowband (%.1f) with MK+ correlator', bandwidth)
+        return None
+        
     # Normal band mask fetching for:
     # - Wide-band observations
     # - Narrow-band observations with the non-MeerKAT-plus correlator

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -6,6 +6,7 @@ It generates telstate state information and a SPEAD stream based on an
 existing katdal dataset or Measurement Set.
 """
 
+from dask.array.routines import append
 import logging
 import time
 import asyncio
@@ -120,7 +121,11 @@ class SimData:
                                'obs_params', f'{correlator_stream}_{ins_name}',
                                f'{correlator_stream}_int_time', f'{correlator_stream}_n_accs',
                                f'{f_engine_stream}_{ins_name}', 'wide_scale_factor_timestamp',
-                               'wide_sync_time', 'cal_src_streams', 'cbf_api_version']
+                               'wide_sync_time', 'cal_src_streams']
+
+        # Include cbf_api_version only when the sensor exists in the telstate.
+        if 'cbf_api_version' in telstate:
+            telstate_immutables.append('cbf_api_version')
 
         for key in telstate_immutables:
             param_dict[key] = telstate[key]

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -6,7 +6,6 @@ It generates telstate state information and a SPEAD stream based on an
 existing katdal dataset or Measurement Set.
 """
 
-from dask.array.routines import append
 import logging
 import time
 import asyncio

--- a/katsdpcal/simulator.py
+++ b/katsdpcal/simulator.py
@@ -120,7 +120,7 @@ class SimData:
                                'obs_params', f'{correlator_stream}_{ins_name}',
                                f'{correlator_stream}_int_time', f'{correlator_stream}_n_accs',
                                f'{f_engine_stream}_{ins_name}', 'wide_scale_factor_timestamp',
-                               'wide_sync_time', 'cal_src_streams']
+                               'wide_sync_time', 'cal_src_streams', 'cbf_api_version']
 
         for key in telstate_immutables:
             param_dict[key] = telstate[key]


### PR DESCRIPTION
This  skips the band mask fetch for narrowband MeerKAT+ observations. The skip is triggered when the bandwidth is narrow and the cbf_api_version corresponds to the MeerKAT+ correlator.  This is because in the MK+ correlator, there is no traditional edge rolloff. 